### PR TITLE
Cadence packaged provision fix

### DIFF
--- a/apis/clusters/v1alpha1/cadence_types.go
+++ b/apis/clusters/v1alpha1/cadence_types.go
@@ -521,10 +521,10 @@ func (cs *CadenceSpec) validatePackagedProvisioning(old []*PackagedProvisioning)
 			if *pp.BundledOpenSearchSpec != *old[i].BundledOpenSearchSpec {
 				return models.ErrImmutablePackagedProvisioning
 			}
-		}
-
-		if pp.BundledKafkaSpec != nil || pp.BundledOpenSearchSpec != nil {
-			return fmt.Errorf("BundledKafkaSpec and BundledOpenSearchSpec structs must be empty because UseAdvancedVisibility is set to false")
+		} else {
+			if pp.BundledKafkaSpec != nil || pp.BundledOpenSearchSpec != nil {
+				return fmt.Errorf("BundledKafkaSpec and BundledOpenSearchSpec structs must be empty because UseAdvancedVisibility is set to false")
+			}
 		}
 
 		if *pp.BundledCassandraSpec != *old[i].BundledCassandraSpec ||

--- a/config/samples/clusters_v1alpha1_postgresql.yaml
+++ b/config/samples/clusters_v1alpha1_postgresql.yaml
@@ -6,7 +6,7 @@ metadata:
     testAnnotation: test
 spec:
   name: "testPostgre"
-  version: "14.5.0"
+  version: "14.6.0"
   dataCentres:
     - region: "US_WEST_2"
       network: "10.1.0.0/16"

--- a/config/samples/clusters_v1alpha1_redis.yaml
+++ b/config/samples/clusters_v1alpha1_redis.yaml
@@ -10,7 +10,7 @@ metadata:
   name: redis-sample
 spec:
   name: "testRedis"
-  version: "7.0.5"
+  version: "7.0.9"
   slaTier: "NON_PRODUCTION"
   clientEncryption: false
   passwordAndUserAuth: false

--- a/controllers/clusters/cassandra_controller_test.go
+++ b/controllers/clusters/cassandra_controller_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Cassandra Controller", func() {
 		c                 = "cassandra"
 		ns                = "default"
 		cassandraNS       = types.NamespacedName{Name: c, Namespace: ns}
-		timeout           = time.Second * 15
+		timeout           = time.Second * 20
 		interval          = time.Second * 2
 	)
 

--- a/controllers/clusters/helpers.go
+++ b/controllers/clusters/helpers.go
@@ -123,6 +123,6 @@ var msgDeleteClusterWithTwoFactorDelete = "Please confirm cluster deletion via e
 	"remove \"triggered\" from Instaclustr.com/clusterDeletion annotation."
 
 var msgExternalChanges = "The k8s specification is different from Instaclustr. Please reconcile the specs manually, " +
-	"add \"instaclustr.com/allowSpecAmend: true \" annotation to be able to change the k8s resource spec."
+	"add \"instaclustr.com/allowSpecAmend: \"true\" \" annotation to be able to change the k8s resource spec."
 
 var msgSpecStillNoMatch = "k8s specification still don't match with Instaclustr Console. Double check the difference."

--- a/controllers/clusters/kafka_controller.go
+++ b/controllers/clusters/kafka_controller.go
@@ -180,13 +180,6 @@ func (r *KafkaReconciler) handleUpdateCluster(
 ) reconcile.Result {
 	l = l.WithName("Kafka update Event")
 
-	if k.Status.ClusterStatus.State != StatusRUNNING {
-		l.Error(instaclustr.ClusterNotRunning, "Unable to update cluster, cluster still not running",
-			"cluster name", k.Spec.Name,
-			"cluster state", k.Status.ClusterStatus.State)
-		return models.ReconcileRequeue
-	}
-
 	iData, err := r.API.GetKafka(k.Status.ID)
 	if err != nil {
 		l.Error(err, "Cannot get cluster from the Instaclustr", "cluster ID", k.Status.ID)
@@ -197,6 +190,13 @@ func (r *KafkaReconciler) handleUpdateCluster(
 	if err != nil {
 		l.Error(err, "Cannot convert cluster from the Instaclustr API", "cluster ID", k.Status.ID)
 		return models.ExitReconcile
+	}
+
+	if iKafka.Status.ClusterStatus.State != StatusRUNNING {
+		l.Error(instaclustr.ClusterNotRunning, "Unable to update cluster, cluster still not running",
+			"cluster name", k.Spec.Name,
+			"cluster state", iKafka.Status.ClusterStatus.State)
+		return models.ReconcileRequeue
 	}
 
 	if k.Annotations[models.ExternalChangesAnnotation] == models.True {

--- a/controllers/clusters/kafka_controller_test.go
+++ b/controllers/clusters/kafka_controller_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Kafka Controller", func() {
 		k             = "kafka"
 		ns            = "default"
 		kafkaNS       = types.NamespacedName{Name: k, Namespace: ns}
-		timeout       = time.Second * 15
+		timeout       = time.Second * 20
 		interval      = time.Second * 2
 	)
 

--- a/controllers/clusters/kafkaconnect_controller_test.go
+++ b/controllers/clusters/kafkaconnect_controller_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Kafka Connect Controller", func() {
 		kc            = "kafkaconnect"
 		ns            = "default"
 		kafkaNS       = types.NamespacedName{Name: kc, Namespace: ns}
-		timeout       = time.Second * 15
+		timeout       = time.Second * 20
 		interval      = time.Second * 2
 	)
 

--- a/controllers/clusters/opensearch_controller.go
+++ b/controllers/clusters/opensearch_controller.go
@@ -641,36 +641,6 @@ func (r *OpenSearchReconciler) newWatchStatusJob(o *clustersv1alpha1.OpenSearch)
 			}
 		}
 
-		activeOperations, err := r.API.GetActiveDataCentreResizeOperations(o.Status.ID, o.Status.CDCID)
-		if err != nil {
-			l.Error(err, "Cannot get active OpenSearch data centre resize operations",
-				"cluster ID", o.Status.ID)
-
-			return err
-		}
-
-		if len(activeOperations) == 0 &&
-			!o.Spec.IsEqual(iO.Spec) {
-			patch := o.NewPatch()
-			o.Spec = iO.Spec
-			err = r.Patch(context.TODO(), o, patch)
-			if err != nil {
-				l.Error(err, "Cannot patch OpenSearch cluster spec",
-					"cluster name", o.Spec.Name,
-					"cluster ID", o.Status.ID,
-					"instaclustr spec", iO.Spec,
-				)
-
-				return err
-			}
-
-			l.Info("OpenSearch cluster spec was updated",
-				"cluster ID", o.Status.ID,
-				"spec", o.Spec,
-			)
-
-		}
-
 		maintEvents, err := r.API.GetMaintenanceEvents(o.Status.ID)
 		if err != nil {
 			l.Error(err, "Cannot get OpenSearch cluster maintenance events",

--- a/controllers/clusters/postgresql_controller_test.go
+++ b/controllers/clusters/postgresql_controller_test.go
@@ -26,7 +26,7 @@ var _ = Describe("PostgreSQL Controller", func() {
 		p                  = "postgresql"
 		ns                 = "default"
 		postgresqlNS       = types.NamespacedName{Name: p, Namespace: ns}
-		timeout            = time.Second * 15
+		timeout            = time.Second * 20
 		interval           = time.Second * 2
 	)
 

--- a/controllers/clusters/redis_controller_test.go
+++ b/controllers/clusters/redis_controller_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Redis Controller", func() {
 		k             = "redis"
 		ns            = "default"
 		redisNS       = types.NamespacedName{Name: k, Namespace: ns}
-		timeout       = time.Second * 15
+		timeout       = time.Second * 20
 		interval      = time.Second * 2
 	)
 

--- a/controllers/kafkamanagement/topic_controller_test.go
+++ b/controllers/kafkamanagement/topic_controller_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Kafka Topic Controller", func() {
 		t             = "topic"
 		ns            = "default"
 		topicNS       = types.NamespacedName{Name: t, Namespace: ns}
-		timeout       = time.Second * 15
+		timeout       = time.Second * 20
 		interval      = time.Second * 2
 	)
 

--- a/pkg/instaclustr/mock/server/go/api.go
+++ b/pkg/instaclustr/mock/server/go/api.go
@@ -539,6 +539,7 @@ type PostgresqlClusterV2ApiServicer interface {
 	ClusterManagementV2ResourcesApplicationsPostgresqlClustersV2ClusterIdPut(context.Context, string, PostgresqlClusterUpdateV2) (ImplResponse, error)
 	ClusterManagementConfigurationV1ResourcesApplicationsPostgresqlClustersV2Put(context.Context) (ImplResponse, error)
 	ClusterManagementV2ResourcesApplicationsPostgresqlClustersV2Post(context.Context, PostgresqlClusterV2) (ImplResponse, error)
+	ClusterManagementMaintenanceEventsV1ResourcesApplicationsPostgresqlClustersV2Get(ctx context.Context, param string) (ImplResponse, error)
 }
 
 // PostgresqlConfigurationV2ApiServicer defines the api actions for the PostgresqlConfigurationV2Api service

--- a/pkg/instaclustr/mock/server/go/api_postgresql_cluster_v2.go
+++ b/pkg/instaclustr/mock/server/go/api_postgresql_cluster_v2.go
@@ -80,6 +80,12 @@ func (c *PostgresqlClusterV2ApiController) Routes() Routes {
 			"/provisioning/v1/{clusterId}",
 			c.ClusterManagementConfigurationV1ResourcesApplicationsPostgresqlClustersV2Put,
 		},
+		{
+			"ClusterManagementMaintenanceEventsV1ResourcesApplicationsPostgresqlClustersV2Get",
+			strings.ToUpper("Get"),
+			"/v1/maintenance-events/events",
+			c.ClusterManagementMaintenanceEventsV1ResourcesApplicationsPostgresqlClustersV2Get,
+		},
 	}
 }
 
@@ -179,4 +185,21 @@ func (c *PostgresqlClusterV2ApiController) ClusterManagementConfigurationV1Resou
 	// If no error, encode the body and the result code
 	EncodeJSONResponse(result.Body, &result.Code, w)
 
+}
+
+// ClusterManagementConfigurationV1ResourcesApplicationsPostgresqlClustersV2Put - Update PostgreSQL cluster details
+func (c *PostgresqlClusterV2ApiController) ClusterManagementMaintenanceEventsV1ResourcesApplicationsPostgresqlClustersV2Get(w http.ResponseWriter, r *http.Request) {
+	// TODO: Remove this method when GetMaintenance is implemented for API v 2.
+
+	clusterIdParam := r.URL.Query().Get("clusterId")
+
+	result, err := c.service.ClusterManagementMaintenanceEventsV1ResourcesApplicationsPostgresqlClustersV2Get(r.Context(), clusterIdParam)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+	// If no error, encode the body and the result code
+	EncodeJSONResponse(result.Body, &result.Code, w)
+	//   'https://api.instaclustr.com/v1/maintenance-events/events?clusterId=string'
 }

--- a/pkg/instaclustr/mock/server/go/api_postgresql_cluster_v2_service.go
+++ b/pkg/instaclustr/mock/server/go/api_postgresql_cluster_v2_service.go
@@ -82,5 +82,12 @@ func (s *PostgresqlClusterV2ApiService) ClusterManagementV2ResourcesApplications
 func (s *PostgresqlClusterV2ApiService) ClusterManagementConfigurationV1ResourcesApplicationsPostgresqlClustersV2Put(ctx context.Context) (ImplResponse, error) {
 	// Add api_postgresql_cluster_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	return Response(202, nil), nil
+	return Response(200, nil), nil
+}
+
+// ClusterManagementMaintenanceEventsV1ResourcesApplicationsPostgresqlClustersV2Get - Get PostgreSQL maintenance
+func (s *PostgresqlClusterV2ApiService) ClusterManagementMaintenanceEventsV1ResourcesApplicationsPostgresqlClustersV2Get(ctx context.Context, clusterId string) (ImplResponse, error) {
+	// Add api_postgresql_cluster_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	return Response(200, nil), nil
 }

--- a/pkg/models/validation.go
+++ b/pkg/models/validation.go
@@ -1,15 +1,15 @@
 package models
 
 var (
-	RedisVersions        = []string{"6.2.7", "7.0.5"}
+	RedisVersions        = []string{"6.2.11", "7.0.9"}
 	CassandraVersions    = []string{"4.0.4", "3.11.13"}
 	SparkVersions        = []string{"2.3.2", "3.0.1"}
 	CadenceVersions      = []string{"0.22.4", "0.24.0"}
-	PostgreSQLVersions   = []string{"15.1.0", "14.6.0", "14.5.0", "13.9.0", "13.8.0"}
+	PostgreSQLVersions   = []string{"15.2.0", "14.6.0", "14.7.0", "13.9.0", "13.10.0"}
 	PGBouncerVersions    = []string{"1.17.0"}
 	KafkaVersions        = []string{"3.3.1", "3.0.2", "3.1.2", "2.8.2"}
 	ZookeeperVersions    = []string{"3.6.3", "3.7.1"}
-	KafkaConnectVersions = []string{"3.1.2", "3.0.2", "2.8.2", "2.7.1"}
+	KafkaConnectVersions = []string{"3.1.2", "3.0.2", "2.8.2", "2.7.1", "3.3.1"}
 	KafkaConnectVPCTypes = []string{"KAFKA_VPC", "VPC_PEERED", "SEPARATE_VPC"}
 	OpenSearchVersions   = []string{"opensearch:1.3.7", "opensearch:2.2.1", "opensearch:1.3.7.ic1", "opensearch:2.2.1.ic1"}
 	PoolModes            = []string{"TRANSACTION", "SESSION", "STATEMENT"}


### PR DESCRIPTION
- cadence packaged provision fix
- clusters versions fix

I suggest to remove the version check of clusters from the webhook because they need to be monitored and updated regularly, ref #410 .