### PR TITLE
ci-cd-fix

### DIFF
--- a/.github/workflows/pre-main-operator-ci-cd.yaml
+++ b/.github/workflows/pre-main-operator-ci-cd.yaml
@@ -35,18 +35,3 @@ jobs:
           sudo apt update
           sudo apt-get install -y make
           make test
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push the Operator image
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/instacluster-operator:io-${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
We will build and push images only from the `main` branch. On other branches, code will be tested and "linted" only,