### PR TITLE
issue-135, saving and updating the PostgreSQL default password were implemented

### DIFF
--- a/config/crd/bases/clusters.instaclustr.com_postgresqls.yaml
+++ b/config/crd/bases/clusters.instaclustr.com_postgresqls.yaml
@@ -228,8 +228,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              defaultUserSecretName:
-                type: string
               id:
                 type: string
               maintenanceEvents:

--- a/controllers/clusterresources/cassandrauser_controller.go
+++ b/controllers/clusterresources/cassandrauser_controller.go
@@ -205,8 +205,8 @@ func (r *CassandraUserReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 func (r *CassandraUserReconciler) getUserCreds(secret *k8sCore.Secret) (username, password string, err error) {
-	password = string(secret.Data["password"])
-	username = string(secret.Data["username"])
+	password = string(secret.Data[models.Password])
+	username = string(secret.Data[models.Username])
 
 	if len(username) == 0 || len(password) == 0 {
 		return "", "", models.ErrMissingSecretKeys

--- a/pkg/models/kafka_user_apv2.go
+++ b/pkg/models/kafka_user_apv2.go
@@ -16,11 +16,6 @@ limitations under the License.
 
 package models
 
-const (
-	Username = "Username"
-	Password = "Password"
-)
-
 type KafkaUser struct {
 	Username           string            `json:"username,omitempty"`
 	Password           string            `json:"password,omitempty"`

--- a/pkg/models/operator.go
+++ b/pkg/models/operator.go
@@ -30,6 +30,7 @@ const (
 	DeletionFinalizer         = "instaclustr.com/deletionFinalizer"
 	StartTimestampAnnotation  = "instaclustr.com/startTimestamp"
 
+	DefaultSecretLabel                = "instaclustr.com/defaultSecret"
 	ControlledByLabel                 = "instaclustr.com/controlledBy"
 	ClusterIDLabel                    = "instaclustr.com/clusterID"
 	ClusterNameLabel                  = "instaclustr.com/clusterName"
@@ -61,18 +62,19 @@ const (
 
 	Triggered = "triggered"
 
-	ClusterBackupKind       = "ClusterBackup"
-	PgClusterKind           = "PostgreSQL"
-	RedisClusterKind        = "Redis"
-	OsClusterKind           = "OpenSearch"
-	CassandraClusterKind    = "Cassandra"
-	ZookeeperClusterKind    = "Zookeeper"
-	SecretKind              = "Secret"
-	PgBackupEventType       = "postgresql-backup"
-	SnapshotUploadEventType = "snapshot-upload"
-	PgBackupPrefix          = "postgresql-backup-"
-	SnapshotUploadPrefix    = "snapshot-upload-"
-	DefaultUserSecretPrefix = "default-user-password-"
+	ClusterBackupKind             = "ClusterBackup"
+	PgClusterKind                 = "PostgreSQL"
+	RedisClusterKind              = "Redis"
+	OsClusterKind                 = "OpenSearch"
+	CassandraClusterKind          = "Cassandra"
+	ZookeeperClusterKind          = "Zookeeper"
+	SecretKind                    = "Secret"
+	PgBackupEventType             = "postgresql-backup"
+	SnapshotUploadEventType       = "snapshot-upload"
+	PgBackupPrefix                = "postgresql-backup-"
+	SnapshotUploadPrefix          = "snapshot-upload-"
+	DefaultUserSecretPrefix       = "default-user-password"
+	DefaultUserSecretNameTemplate = "%s-%s"
 
 	CassandraConnectionPort    = 9042
 	CadenceConnectionPort      = 7933
@@ -101,6 +103,8 @@ const (
 	KafkaConnectAppType = "KAFKA_CONNECT"
 	CassandraAppType    = "APACHE_CASSANDRA"
 	SparkAppType        = "SPARK"
+
+	DefaultPgUsernameValue = "icpostgresql"
 )
 
 const (
@@ -124,6 +128,7 @@ const (
 	FetchFailed       = "FetchFailed"
 	FetchSecretFailed = "FetchSecretFailed"
 	ConvertionFailed  = "ConvertionFailed"
+	ValidationFailed  = "ValidationFailed"
 	UpdateFailed      = "UpdateFailed"
 	UpdatedSecret     = "UpdatedSecret"
 	ExternalChanges   = "ExternalChanges"
@@ -133,10 +138,12 @@ const (
 )
 
 const (
-	ReplaceOperation    = "replace"
-	AnnotationsPath     = "/metadata/annotations"
-	FinalizersPath      = "/metadata/finalizers"
-	DefaultUserPassword = "defaultUserPassword"
+	ReplaceOperation = "replace"
+	AnnotationsPath  = "/metadata/annotations"
+	FinalizersPath   = "/metadata/finalizers"
+
+	Username = "username"
+	Password = "password"
 )
 
 const Requeue60 = time.Second * 60


### PR DESCRIPTION
Closes #446 
We need to get default user password and store it in secret to be able to create new PostgreSQL user.
In this Pr, I updated the current logic for creating secret with default user password and username when cluster is creating.
Also, fixed and improved logic for updating default password when secret is updated.
