### PR TITLE
Added users graceful creation during OpenSearch cluster creation phase

### DIFF
--- a/controllers/clusterresources/opensearchuser_controller.go
+++ b/controllers/clusterresources/opensearchuser_controller.go
@@ -272,7 +272,7 @@ func (r *OpenSearchUserReconciler) deleteUser(
 			user, models.Warning, models.DeletingEvent,
 			"Resource deleting has been failed. Reason: %v", err,
 		)
-		return nil
+		return err
 	}
 
 	err = r.API.DeleteUser(username, clusterID, models.OpenSearchAppKind)
@@ -285,7 +285,7 @@ func (r *OpenSearchUserReconciler) deleteUser(
 			"Resource deletion on Instaclustr has been failed. Reason: %v",
 			err,
 		)
-		return nil
+		return err
 	}
 
 	r.EventRecorder.Eventf(
@@ -305,7 +305,7 @@ func (r *OpenSearchUserReconciler) deleteUser(
 			"Deleting clusterID from the OpenSearch user resource has been failed. Reason: %v",
 			err,
 		)
-		return nil
+		return err
 	}
 
 	patch = user.NewPatch()
@@ -320,7 +320,7 @@ func (r *OpenSearchUserReconciler) deleteUser(
 			"Deleting finalizer from the OpenSearch user resource has been failed. Reason: %v",
 			err,
 		)
-		return nil
+		return err
 	}
 
 	logger.Info("OpenSearch user has been deleted from the cluster",
@@ -352,7 +352,7 @@ func (r *OpenSearchUserReconciler) detachUserFromDeletedCluster(
 			"Detaching clusterID from the OpenSearch user resource has been failed. Reason: %v",
 			err,
 		)
-		return nil
+		return err
 	}
 
 	patch = user.NewPatch()
@@ -367,7 +367,7 @@ func (r *OpenSearchUserReconciler) detachUserFromDeletedCluster(
 			"Deleting finalizer from the OpenSearch user resource has been failed. Reason: %v",
 			err,
 		)
-		return nil
+		return err
 	}
 
 	logger.Info("OpenSearch user has been deleted from the cluster",

--- a/main.go
+++ b/main.go
@@ -71,6 +71,8 @@ func main() {
 		"An interval to check cluster status")
 	flag.DurationVar(&scheduler.ClusterBackupsInterval, "cluster-backups-interval", 60*time.Second,
 		"An interval to check cluster backups")
+	flag.DurationVar(&scheduler.UserCreationInterval, "user-creation-interval", 60*time.Second,
+		"An interval to try to create user during cluster creation")
 	opts := zap.Options{
 		Development: true,
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -26,9 +26,11 @@ import (
 
 var ClusterStatusInterval time.Duration
 var ClusterBackupsInterval time.Duration
+var UserCreationInterval time.Duration
 
 const StatusChecker = "statusChecker"
 const BackupsChecker = "backupsChecker"
+const UserCreator = "userCreator"
 
 type Job func() error
 


### PR DESCRIPTION
Implemented graceful creation of users when the OpenSearch cluster is not in the running state. Now it starts a job that checks if a cluster is in the running state and then creates users and removes itself.

* closes #482 