### PR TITLE
Saving default Kafka Connect user credentials

### DIFF
--- a/apis/clusters/v1beta1/kafkaconnect_types.go
+++ b/apis/clusters/v1beta1/kafkaconnect_types.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -686,4 +687,25 @@ func (tc *TargetCluster) ManagedClustersToInstAPI() (iClusters []*models.Managed
 		})
 	}
 	return
+}
+
+func (k *KafkaConnect) NewDefaultUserSecret(username, password string) *v1.Secret {
+	return &v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       models.SecretKind,
+			APIVersion: models.K8sAPIVersionV1,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf(models.DefaultUserSecretNameTemplate, models.DefaultUserSecretPrefix, k.Name),
+			Namespace: k.Namespace,
+			Labels: map[string]string{
+				models.ControlledByLabel:  k.Name,
+				models.DefaultSecretLabel: "true",
+			},
+		},
+		StringData: map[string]string{
+			models.Username: username,
+			models.Password: password,
+		},
+	}
 }

--- a/pkg/instaclustr/interfaces.go
+++ b/pkg/instaclustr/interfaces.go
@@ -96,4 +96,5 @@ type API interface {
 	CreateUser(userSpec any, clusterID, app string) error
 	DeleteUser(username, clusterID, app string) error
 	ListAppVersions(app string) ([]*models.AppVersions, error)
+	GetDefaultCredentialsV1(clusterID string) (string, string, error)
 }

--- a/pkg/instaclustr/mock/client.go
+++ b/pkg/instaclustr/mock/client.go
@@ -343,3 +343,7 @@ func (c *mockClient) CreateUser(userSpec any, clusterID, app string) error {
 func (c *mockClient) DeleteUser(username, clusterID, app string) error {
 	panic("DeleteUser: is not implemented")
 }
+
+func (c *mockClient) GetDefaultCredentialsV1(clusterID string) (string, string, error) {
+	panic("GetDefaultCredentialsV1: is not implemented")
+}


### PR DESCRIPTION
## Kafka connect credentials lifecycle #488
Implemented by saving default user's credentials to k8s secret. It creates a secret in the same namespace as the cluster was created. The name of the secret is `default-user-password-` prefix + the cluster CRD metadata name. 

* closes #488 