### PR TITLE
Immutable fields for OpenSearchUser CRD

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -278,4 +278,16 @@ resources:
   kind: Topic
   path: github.com/instaclustr/operator/apis/kafkamanagement/v1beta1
   version: v1beta1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: instaclustr.com
+  group: clusterresources
+  kind: OpenSearchUser
+  path: github.com/instaclustr/operator/apis/clusterresources/v1beta1
+  version: v1beta1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 version: "3"

--- a/apis/clusterresources/v1beta1/opensearchuser_webhook.go
+++ b/apis/clusterresources/v1beta1/opensearchuser_webhook.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var opensearchuserlog = logf.Log.WithName("opensearchuser-resource")
+
+func (u *OpenSearchUser) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(u).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-clusterresources-instaclustr-com-v1beta1-opensearchuser,mutating=false,failurePolicy=fail,sideEffects=None,groups=clusterresources.instaclustr.com,resources=opensearchusers,verbs=create;update,versions=v1beta1,name=vopensearchuser.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &OpenSearchUser{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (u *OpenSearchUser) ValidateCreate() error {
+	opensearchuserlog.Info("validate create", "name", u.Name)
+
+	if u.Spec.SecretRef.Name == "" || u.Spec.SecretRef.Namespace == "" {
+		return fmt.Errorf("secretRef.name and secretRef.namespace should not be empty")
+	}
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (u *OpenSearchUser) ValidateUpdate(old runtime.Object) error {
+	opensearchuserlog.Info("validate update", "name", u.Name)
+
+	oldUser := old.(*OpenSearchUser)
+	if u.Spec.SecretRef != oldUser.Spec.SecretRef {
+		return fmt.Errorf("spec.secretRef field is immutable")
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (u *OpenSearchUser) ValidateDelete() error {
+	return nil
+}

--- a/apis/clusterresources/v1beta1/webhook_suite_test.go
+++ b/apis/clusterresources/v1beta1/webhook_suite_test.go
@@ -120,6 +120,9 @@ var _ = BeforeSuite(func() {
 	err = (&AWSEncryptionKey{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&OpenSearchUser{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -338,6 +338,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-clusterresources-instaclustr-com-v1beta1-opensearchuser
+  failurePolicy: Fail
+  name: vopensearchuser.kb.io
+  rules:
+  - apiGroups:
+    - clusterresources.instaclustr.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - opensearchusers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-clusters-instaclustr-com-v1beta1-cadence
   failurePolicy: Fail
   name: vcadence.kb.io

--- a/main.go
+++ b/main.go
@@ -420,6 +420,10 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenSearchUser")
 		os.Exit(1)
 	}
+	if err = (&clusterresourcesv1beta1.OpenSearchUser{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchUser")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
Added validation webhook to make OpenSearchUser fields `spec.name` and `spec.namespace` immutable.