### PR TITLE
Adjustments to defaulter webhooks of clusters group

### DIFF
--- a/apis/clusters/v1beta1/cadence_webhook.go
+++ b/apis/clusters/v1beta1/cadence_webhook.go
@@ -51,6 +51,12 @@ var _ webhook.Defaulter = &Cadence{}
 func (c *Cadence) Default() {
 	cadencelog.Info("default", "name", c.Name)
 
+	if c.GetAnnotations() == nil {
+		c.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+
 	for _, dataCentre := range c.Spec.DataCentres {
 		dataCentre.SetDefaultValues()
 	}

--- a/apis/clusters/v1beta1/cassandra_webhook.go
+++ b/apis/clusters/v1beta1/cassandra_webhook.go
@@ -44,7 +44,7 @@ func (r *Cassandra) SetupWebhookWithManager(mgr ctrl.Manager, api validation.Val
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/mutate-clusters-instaclustr-com-v1beta1-cassandra,mutating=true,failurePolicy=fail,sideEffects=None,groups=clusters.instaclustr.com,resources=cassandras,verbs=create;update,versions=v1beta1,name=vcassandra.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/mutate-clusters-instaclustr-com-v1beta1-cassandra,mutating=true,failurePolicy=fail,sideEffects=None,groups=clusters.instaclustr.com,resources=cassandras,verbs=create;update,versions=v1beta1,name=mcassandra.kb.io,admissionReviewVersions=v1
 //+kubebuilder:webhook:path=/validate-clusters-instaclustr-com-v1beta1-cassandra,mutating=false,failurePolicy=fail,sideEffects=None,groups=clusters.instaclustr.com,resources=cassandras,verbs=create;update,versions=v1beta1,name=vcassandra.kb.io,admissionReviewVersions=v1
 
 var _ webhook.CustomValidator = &cassandraValidator{}
@@ -52,6 +52,14 @@ var _ webhook.Defaulter = &Cassandra{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (c *Cassandra) Default() {
+	cassandralog.Info("default", "name", c.Name)
+
+	if c.GetAnnotations() == nil {
+		c.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+
 	for _, dataCentre := range c.Spec.DataCentres {
 		dataCentre.SetDefaultValues()
 	}

--- a/apis/clusters/v1beta1/kafka_webhook.go
+++ b/apis/clusters/v1beta1/kafka_webhook.go
@@ -51,6 +51,12 @@ var _ webhook.Defaulter = &Kafka{}
 func (k *Kafka) Default() {
 	kafkalog.Info("default", "name", k.Name)
 
+	if k.GetAnnotations() == nil {
+		k.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+
 	for _, dataCentre := range k.Spec.DataCentres {
 		dataCentre.SetDefaultValues()
 	}

--- a/apis/clusters/v1beta1/kafkaconnect_webhook.go
+++ b/apis/clusters/v1beta1/kafkaconnect_webhook.go
@@ -52,6 +52,12 @@ var _ webhook.Defaulter = &KafkaConnect{}
 func (r *KafkaConnect) Default() {
 	kafkaconnectlog.Info("default", "name", r.Name)
 
+	if r.GetAnnotations() == nil {
+		r.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+
 	for _, dataCentre := range r.Spec.DataCentres {
 		dataCentre.SetDefaultValues()
 	}

--- a/apis/clusters/v1beta1/opensearch_webhook.go
+++ b/apis/clusters/v1beta1/opensearch_webhook.go
@@ -55,6 +55,12 @@ func (os *OpenSearch) Default() {
 	for _, dataCentre := range os.Spec.DataCentres {
 		setDefaultValues(dataCentre)
 
+		if os.GetAnnotations() == nil {
+			os.SetAnnotations(map[string]string{
+				models.ResourceStateAnnotation: "",
+			})
+		}
+
 		if dataCentre.Name == "" {
 			dataCentre.Name = dataCentre.Region
 		}

--- a/apis/clusters/v1beta1/postgresql_webhook.go
+++ b/apis/clusters/v1beta1/postgresql_webhook.go
@@ -52,6 +52,14 @@ var _ webhook.Defaulter = &PostgreSQL{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (pg *PostgreSQL) Default() {
+	postgresqllog.Info("default", "name", pg.Name)
+
+	if pg.GetAnnotations() == nil {
+		pg.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+
 	for _, dataCentre := range pg.Spec.DataCentres {
 		dataCentre.SetDefaultValues()
 	}

--- a/apis/clusters/v1beta1/redis_webhook.go
+++ b/apis/clusters/v1beta1/redis_webhook.go
@@ -49,6 +49,14 @@ var _ webhook.Defaulter = &Redis{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Redis) Default() {
+	redislog.Info("default", "name", r.Name)
+
+	if r.GetAnnotations() == nil {
+		r.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+
 	for _, dataCentre := range r.Spec.DataCentres {
 		dataCentre.SetDefaultValues()
 	}

--- a/apis/clusters/v1beta1/zookeeper_webhook.go
+++ b/apis/clusters/v1beta1/zookeeper_webhook.go
@@ -49,6 +49,14 @@ var _ webhook.Defaulter = &Zookeeper{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (z *Zookeeper) Default() {
+	redislog.Info("default", "name", z.Name)
+
+	if z.GetAnnotations() == nil {
+		z.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+
 	for _, dataCentre := range z.Spec.DataCentres {
 		dataCentre.SetDefaultValues()
 	}

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -33,7 +33,7 @@ webhooks:
       namespace: system
       path: /mutate-clusters-instaclustr-com-v1beta1-cassandra
   failurePolicy: Fail
-  name: vcassandra.kb.io
+  name: mcassandra.kb.io
   rules:
   - apiGroups:
     - clusters.instaclustr.com


### PR DESCRIPTION
Ref #495 
When using a `kubectl create` command, we get a panic. To prevent this, I initialized the k8s resource annotation in the default webhook.