### PR TITLE
User creation job removing bug

### DIFF
--- a/controllers/clusterresources/opensearchuser_controller.go
+++ b/controllers/clusterresources/opensearchuser_controller.go
@@ -253,6 +253,10 @@ func (r *OpenSearchUserReconciler) createUser(
 	logger.Info("OpenSearch user has been created",
 		"cluster ID", clusterID,
 	)
+	r.EventRecorder.Eventf(user, models.Normal, models.Created,
+		"OpenSearch user resource has been created on the cluster with ID: %v",
+		clusterID,
+	)
 
 	return nil
 }


### PR DESCRIPTION
Fixed a bug, when the user creation job removes itself and then doesn't unlock Mutex.

It happens because a job tries to write in a `done` channel and then `select` receives a signal from the `done` channel. When it receives a signal from the `done` it finishes the current goroutine without unlocking the mutex.

closes #499