### PR TITLE
Datacenters newly added DataCentres validation

### DIFF
--- a/apis/clusters/v1beta1/opensearch_webhook.go
+++ b/apis/clusters/v1beta1/opensearch_webhook.go
@@ -326,8 +326,8 @@ func (oss *OpenSearchSpec) validateUpdate(oldSpec OpenSearchSpec) error {
 
 func (oss *OpenSearchSpec) validateImmutableDataCentresUpdate(oldDCs []*OpenSearchDataCentre) error {
 	newDCs := oss.DataCentres
-	if len(newDCs) < len(oldDCs) {
-		return models.ErrImmutableDataCentres
+	if len(newDCs) != len(oldDCs) {
+		return models.ErrImmutableDataCentresNumber
 	}
 
 	for _, newDC := range newDCs {


### PR DESCRIPTION
Added some improvements to validation webhooks for OpenSearch and Cassandra.

Done:
- for Cassandra added validation of newly added Datacentres.
- for OpenSearch added validation of datacentres number. As the Instaclustr API doc says we can't add datacentres to the OpenSearch cluster.

ref #423