### PR TITLE
ResourceStateAnnotation fix for clusterresource and kafkamanagement api groups

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -123,6 +123,7 @@ resources:
   path: github.com/instaclustr/operator/apis/clusterresources/v1beta1
   version: v1beta1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 - api:
@@ -135,6 +136,7 @@ resources:
   path: github.com/instaclustr/operator/apis/clusterresources/v1beta1
   version: v1beta1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 - api:
@@ -147,6 +149,7 @@ resources:
   path: github.com/instaclustr/operator/apis/clusterresources/v1beta1
   version: v1beta1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 - api:
@@ -159,6 +162,7 @@ resources:
   path: github.com/instaclustr/operator/apis/clusterresources/v1beta1
   version: v1beta1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 - api:
@@ -192,6 +196,7 @@ resources:
   path: github.com/instaclustr/operator/apis/clusterresources/v1beta1
   version: v1beta1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 - api:
@@ -204,6 +209,7 @@ resources:
   path: github.com/instaclustr/operator/apis/clusterresources/v1beta1
   version: v1beta1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 - api:
@@ -249,6 +255,7 @@ resources:
   path: github.com/instaclustr/operator/apis/kafkamanagement/v1beta1
   version: v1beta1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 - api:
@@ -260,6 +267,9 @@ resources:
   kind: KafkaUser
   path: github.com/instaclustr/operator/apis/kafkamanagement/v1beta1
   version: v1beta1
+  webhooks:
+    defaulting: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true
@@ -269,6 +279,9 @@ resources:
   kind: Mirror
   path: github.com/instaclustr/operator/apis/kafkamanagement/v1beta1
   version: v1beta1
+  webhooks:
+    defaulting: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true
@@ -278,6 +291,9 @@ resources:
   kind: Topic
   path: github.com/instaclustr/operator/apis/kafkamanagement/v1beta1
   version: v1beta1
+  webhooks:
+    defaulting: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/apis/clusterresources/v1beta1/awsencryptionkey_webhook.go
+++ b/apis/clusterresources/v1beta1/awsencryptionkey_webhook.go
@@ -36,6 +36,21 @@ func (aws *AWSEncryptionKey) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
+//+kubebuilder:webhook:path=/mutate-clusterresources-instaclustr-com-v1beta1-awsencryptionkey,mutating=true,failurePolicy=fail,sideEffects=None,groups=clusterresources.instaclustr.com,resources=awsencryptionkeys,verbs=create;update,versions=v1beta1,name=mawsencryptionkey.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &AWSEncryptionKey{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (aws *AWSEncryptionKey) Default() {
+	awsencryptionkeylog.Info("default", "name", aws.Name)
+
+	if aws.GetAnnotations() == nil {
+		aws.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+}
+
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-clusterresources-instaclustr-com-v1beta1-awsencryptionkey,mutating=false,failurePolicy=fail,sideEffects=None,groups=clusterresources.instaclustr.com,resources=awsencryptionkeys,verbs=create;update,versions=v1beta1,name=vawsencryptionkey.kb.io,admissionReviewVersions=v1
 

--- a/apis/clusterresources/v1beta1/awssecuritygroupfirewallrule_webhook.go
+++ b/apis/clusterresources/v1beta1/awssecuritygroupfirewallrule_webhook.go
@@ -36,6 +36,21 @@ func (r *AWSSecurityGroupFirewallRule) SetupWebhookWithManager(mgr ctrl.Manager)
 		Complete()
 }
 
+//+kubebuilder:webhook:path=/mutate-clusterresources-instaclustr-com-v1beta1-awssecuritygroupfirewallrule,mutating=true,failurePolicy=fail,sideEffects=None,groups=clusterresources.instaclustr.com,resources=awssecuritygroupfirewallrules,verbs=create;update,versions=v1beta1,name=mawssecuritygroupfirewallrule.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &AWSSecurityGroupFirewallRule{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *AWSSecurityGroupFirewallRule) Default() {
+	awssecuritygroupfirewallrulelog.Info("default", "name", r.Name)
+
+	if r.GetAnnotations() == nil {
+		r.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+}
+
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-clusterresources-instaclustr-com-v1beta1-awssecuritygroupfirewallrule,mutating=false,failurePolicy=fail,sideEffects=None,groups=clusterresources.instaclustr.com,resources=awssecuritygroupfirewallrules,verbs=create;update,versions=v1beta1,name=vawssecuritygroupfirewallrule.kb.io,admissionReviewVersions=v1
 

--- a/apis/clusterresources/v1beta1/awsvpcpeering_webhook.go
+++ b/apis/clusterresources/v1beta1/awsvpcpeering_webhook.go
@@ -35,6 +35,21 @@ func (r *AWSVPCPeering) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
+//+kubebuilder:webhook:path=/mutate-clusterresources-instaclustr-com-v1beta1-awsvpcpeering,mutating=true,failurePolicy=fail,sideEffects=None,groups=clusterresources.instaclustr.com,resources=awsvpcpeerings,verbs=create;update,versions=v1beta1,name=mawsvpcpeering.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &AWSVPCPeering{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *AWSVPCPeering) Default() {
+	awsvpcpeeringlog.Info("default", "name", r.Name)
+
+	if r.GetAnnotations() == nil {
+		r.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+}
+
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-clusterresources-instaclustr-com-v1beta1-awsvpcpeering,mutating=false,failurePolicy=fail,sideEffects=None,groups=clusterresources.instaclustr.com,resources=awsvpcpeerings,verbs=create;update,versions=v1beta1,name=vawsvpcpeering.kb.io,admissionReviewVersions=v1
 

--- a/apis/clusterresources/v1beta1/azurevnetpeering_webhook.go
+++ b/apis/clusterresources/v1beta1/azurevnetpeering_webhook.go
@@ -23,6 +23,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/instaclustr/operator/pkg/models"
 )
 
 var azurevnetpeeringlog = logf.Log.WithName("azurevnetpeering-resource")
@@ -31,6 +33,21 @@ func (r *AzureVNetPeering) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-clusterresources-instaclustr-com-v1beta1-azurevnetpeering,mutating=true,failurePolicy=fail,sideEffects=None,groups=clusterresources.instaclustr.com,resources=azurevnetpeerings,verbs=create;update,versions=v1beta1,name=mazurevnetpeering.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &AzureVNetPeering{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *AzureVNetPeering) Default() {
+	azurevnetpeeringlog.Info("default", "name", r.Name)
+
+	if r.GetAnnotations() == nil {
+		r.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.

--- a/apis/clusterresources/v1beta1/cassandrauser_types.go
+++ b/apis/clusterresources/v1beta1/cassandrauser_types.go
@@ -58,7 +58,6 @@ type CassandraUserList struct {
 
 func (r *CassandraUser) NewPatch() client.Patch {
 	old := r.DeepCopy()
-	old.Annotations[models.ResourceStateAnnotation] = ""
 	return client.MergeFrom(old)
 }
 

--- a/apis/clusterresources/v1beta1/clusternetworkfirewallrule_webhook.go
+++ b/apis/clusterresources/v1beta1/clusternetworkfirewallrule_webhook.go
@@ -36,6 +36,21 @@ func (fr *ClusterNetworkFirewallRule) SetupWebhookWithManager(mgr ctrl.Manager) 
 		Complete()
 }
 
+//+kubebuilder:webhook:path=/mutate-clusterresources-instaclustr-com-v1beta1-clusternetworkfirewallrule,mutating=true,failurePolicy=fail,sideEffects=None,groups=clusterresources.instaclustr.com,resources=clusternetworkfirewallrules,verbs=create;update,versions=v1beta1,name=mclusternetworkfirewallrule.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &ClusterNetworkFirewallRule{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *ClusterNetworkFirewallRule) Default() {
+	clusternetworkfirewallrulelog.Info("default", "name", r.Name)
+
+	if r.GetAnnotations() == nil {
+		r.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+}
+
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-clusterresources-instaclustr-com-v1beta1-clusternetworkfirewallrule,mutating=false,failurePolicy=fail,sideEffects=None,groups=clusterresources.instaclustr.com,resources=clusternetworkfirewallrules,verbs=create;update,versions=v1beta1,name=vclusternetworkfirewallrule.kb.io,admissionReviewVersions=v1
 

--- a/apis/clusterresources/v1beta1/gcpvpcpeering_webhook.go
+++ b/apis/clusterresources/v1beta1/gcpvpcpeering_webhook.go
@@ -23,6 +23,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/instaclustr/operator/pkg/models"
 )
 
 var gcpvpcpeeringlog = logf.Log.WithName("gcpvpcpeering-resource")
@@ -31,6 +33,21 @@ func (r *GCPVPCPeering) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-clusterresources-instaclustr-com-v1beta1-gcpvpcpeering,mutating=true,failurePolicy=fail,sideEffects=None,groups=clusterresources.instaclustr.com,resources=gcpvpcpeerings,verbs=create;update,versions=v1beta1,name=mgcpvpcpeering.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &GCPVPCPeering{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *GCPVPCPeering) Default() {
+	gcpvpcpeeringlog.Info("default", "name", r.Name)
+
+	if r.GetAnnotations() == nil {
+		r.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.

--- a/apis/kafkamanagement/v1beta1/kafkaacl_webhook.go
+++ b/apis/kafkamanagement/v1beta1/kafkaacl_webhook.go
@@ -33,6 +33,21 @@ func (kacl *KafkaACL) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
+//+kubebuilder:webhook:path=/mutate-kafkamanagement-instaclustr-com-v1beta1-kafkaacl,mutating=true,failurePolicy=fail,sideEffects=None,groups=kafkamanagement.instaclustr.com,resources=kafkaacls,verbs=create;update,versions=v1beta1,name=mkafkaacl.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &KafkaACL{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *KafkaACL) Default() {
+	kafkaacllog.Info("default", "name", r.Name)
+
+	if r.GetAnnotations() == nil {
+		r.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+}
+
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-kafkamanagement-instaclustr-com-v1beta1-kafkaacl,mutating=false,failurePolicy=fail,sideEffects=None,groups=kafkamanagement.instaclustr.com,resources=kafkaacls,verbs=create;update,versions=v1beta1,name=vkafkaacl.kb.io,admissionReviewVersions=v1
 

--- a/apis/kafkamanagement/v1beta1/kafkauser_types.go
+++ b/apis/kafkamanagement/v1beta1/kafkauser_types.go
@@ -68,7 +68,6 @@ func (ku *KafkaUser) GetJobID(jobName string) string {
 
 func (ku *KafkaUser) NewPatch() client.Patch {
 	old := ku.DeepCopy()
-	old.Annotations[models.ResourceStateAnnotation] = ""
 	return client.MergeFrom(old)
 }
 

--- a/apis/kafkamanagement/v1beta1/kafkauser_webhook.go
+++ b/apis/kafkamanagement/v1beta1/kafkauser_webhook.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/instaclustr/operator/pkg/models"
+)
+
+// log is for logging in this package.
+var kafkauserlog = logf.Log.WithName("kafkauser-resource")
+
+func (r *KafkaUser) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-kafkamanagement-instaclustr-com-v1beta1-kafkauser,mutating=true,failurePolicy=fail,sideEffects=None,groups=kafkamanagement.instaclustr.com,resources=kafkausers,verbs=create;update,versions=v1beta1,name=mkafkauser.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &KafkaUser{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *KafkaUser) Default() {
+	kafkauserlog.Info("default", "name", r.Name)
+
+	if r.GetAnnotations() == nil {
+		r.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+}

--- a/apis/kafkamanagement/v1beta1/mirror_webhook.go
+++ b/apis/kafkamanagement/v1beta1/mirror_webhook.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/instaclustr/operator/pkg/models"
+)
+
+// log is for logging in this package.
+var mirrorlog = logf.Log.WithName("mirror-resource")
+
+func (r *Mirror) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-kafkamanagement-instaclustr-com-v1beta1-mirror,mutating=true,failurePolicy=fail,sideEffects=None,groups=kafkamanagement.instaclustr.com,resources=mirrors,verbs=create;update,versions=v1beta1,name=mmirror.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &Mirror{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *Mirror) Default() {
+	mirrorlog.Info("default", "name", r.Name)
+
+	if r.GetAnnotations() == nil {
+		r.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+}

--- a/apis/kafkamanagement/v1beta1/topic_webhook.go
+++ b/apis/kafkamanagement/v1beta1/topic_webhook.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/instaclustr/operator/pkg/models"
+)
+
+// log is for logging in this package.
+var topiclog = logf.Log.WithName("topic-resource")
+
+func (r *Topic) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-kafkamanagement-instaclustr-com-v1beta1-topic,mutating=true,failurePolicy=fail,sideEffects=None,groups=kafkamanagement.instaclustr.com,resources=topics,verbs=create;update,versions=v1beta1,name=mtopic.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &Topic{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *Topic) Default() {
+	topiclog.Info("default", "name", r.Name)
+
+	if r.GetAnnotations() == nil {
+		r.SetAnnotations(map[string]string{
+			models.ResourceStateAnnotation: "",
+		})
+	}
+}

--- a/apis/kafkamanagement/v1beta1/webhook_suite_test.go
+++ b/apis/kafkamanagement/v1beta1/webhook_suite_test.go
@@ -99,6 +99,15 @@ var _ = BeforeSuite(func() {
 	err = (&KafkaACL{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&Mirror{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&Topic{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&KafkaUser{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -11,6 +11,126 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-clusterresources-instaclustr-com-v1beta1-awsencryptionkey
+  failurePolicy: Fail
+  name: mawsencryptionkey.kb.io
+  rules:
+  - apiGroups:
+    - clusterresources.instaclustr.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsencryptionkeys
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-clusterresources-instaclustr-com-v1beta1-awssecuritygroupfirewallrule
+  failurePolicy: Fail
+  name: mawssecuritygroupfirewallrule.kb.io
+  rules:
+  - apiGroups:
+    - clusterresources.instaclustr.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awssecuritygroupfirewallrules
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-clusterresources-instaclustr-com-v1beta1-awsvpcpeering
+  failurePolicy: Fail
+  name: mawsvpcpeering.kb.io
+  rules:
+  - apiGroups:
+    - clusterresources.instaclustr.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsvpcpeerings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-clusterresources-instaclustr-com-v1beta1-azurevnetpeering
+  failurePolicy: Fail
+  name: mazurevnetpeering.kb.io
+  rules:
+  - apiGroups:
+    - clusterresources.instaclustr.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - azurevnetpeerings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-clusterresources-instaclustr-com-v1beta1-clusternetworkfirewallrule
+  failurePolicy: Fail
+  name: mclusternetworkfirewallrule.kb.io
+  rules:
+  - apiGroups:
+    - clusterresources.instaclustr.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusternetworkfirewallrules
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-clusterresources-instaclustr-com-v1beta1-gcpvpcpeering
+  failurePolicy: Fail
+  name: mgcpvpcpeering.kb.io
+  rules:
+  - apiGroups:
+    - clusterresources.instaclustr.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gcpvpcpeerings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-clusters-instaclustr-com-v1beta1-cadence
   failurePolicy: Fail
   name: mcadence.kb.io
@@ -164,6 +284,86 @@ webhooks:
     - UPDATE
     resources:
     - zookeepers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-kafkamanagement-instaclustr-com-v1beta1-kafkaacl
+  failurePolicy: Fail
+  name: mkafkaacl.kb.io
+  rules:
+  - apiGroups:
+    - kafkamanagement.instaclustr.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kafkaacls
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-kafkamanagement-instaclustr-com-v1beta1-kafkauser
+  failurePolicy: Fail
+  name: mkafkauser.kb.io
+  rules:
+  - apiGroups:
+    - kafkamanagement.instaclustr.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kafkausers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-kafkamanagement-instaclustr-com-v1beta1-mirror
+  failurePolicy: Fail
+  name: mmirror.kb.io
+  rules:
+  - apiGroups:
+    - kafkamanagement.instaclustr.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - mirrors
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-kafkamanagement-instaclustr-com-v1beta1-topic
+  failurePolicy: Fail
+  name: mtopic.kb.io
+  rules:
+  - apiGroups:
+    - kafkamanagement.instaclustr.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - topics
   sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/main.go
+++ b/main.go
@@ -428,6 +428,18 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "CassandraUser")
 		os.Exit(1)
 	}
+	if err = (&kafkamanagementv1beta1.Mirror{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "Mirror")
+		os.Exit(1)
+	}
+	if err = (&kafkamanagementv1beta1.Topic{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "Topic")
+		os.Exit(1)
+	}
+	if err = (&kafkamanagementv1beta1.KafkaUser{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "KafkaUser")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
Added adjustments to defaulting webhooks of **clusterresource** and **kafkamanagement** API group to prevent panics of nil pointer. For more information follow #495.

Added defaulting webhooks for resources in **clusterresource** API group:
- AWSEncryptionKey
- AWSSecurityGroupFirewallRule
- AWSVPCPeering
- AzureVNetPeering
- ClusterNetworkFirewallRule
- GCPVPCPeering

Added defaulting webhooks for resources in **kafkamanagement** API group:
- KafkaACL
- Mirror
- Topic
- KafkaUser

closes #510
closes #512 