### PR TITLE
Fixes for the User CRDs

### DIFF
--- a/apis/clusterresources/v1beta1/redisuser_types.go
+++ b/apis/clusterresources/v1beta1/redisuser_types.go
@@ -69,10 +69,6 @@ func (r *RedisUser) GetDeletionFinalizer() string {
 	return models.DeletionFinalizer + "_" + r.Namespace + "_" + r.Name
 }
 
-func (r *RedisUser) DeletionUserFinalizer(clusterID, namespace string) string {
-	return models.DeletionUserFinalizer + clusterID + "_" + namespace
-}
-
 func (r *RedisUser) ToInstAPIUpdate(password, id string) *models.RedisUserUpdate {
 	return &models.RedisUserUpdate{
 		ID:       id,

--- a/apis/kafkamanagement/v1beta1/kafkauser_types.go
+++ b/apis/kafkamanagement/v1beta1/kafkauser_types.go
@@ -75,10 +75,6 @@ func (ku *KafkaUser) GetDeletionFinalizer() string {
 	return models.DeletionFinalizer + "_" + ku.Namespace + "_" + ku.Name
 }
 
-func (ku *KafkaUser) GetDeletionUserFinalizer(clusterID string) string {
-	return models.DeletionUserFinalizer + clusterID
-}
-
 func (ku *KafkaUser) GetID(clusterID, name string) string {
 	return clusterID + "_" + name
 }

--- a/controllers/clusterresources/helpers.go
+++ b/controllers/clusterresources/helpers.go
@@ -75,7 +75,3 @@ func getUserCreds(secret *k8sCore.Secret) (username, password string, err error)
 
 	return username[:len(username)-1], password[:len(password)-1], nil
 }
-
-func getDeletionUserFinalizer(clusterID string) string {
-	return models.DeletionUserFinalizer + clusterID
-}

--- a/controllers/clusters/cassandra_controller.go
+++ b/controllers/clusters/cassandra_controller.go
@@ -772,6 +772,8 @@ func (r *CassandraReconciler) handleUsersDetach(
 		return err
 	}
 
+	l.Info("User has been added to the queue for detaching", "username", u.Name)
+
 	return nil
 }
 

--- a/controllers/clusters/kafka_controller.go
+++ b/controllers/clusters/kafka_controller.go
@@ -336,6 +336,8 @@ func (r *KafkaReconciler) handleCreateUser(
 		return err
 	}
 
+	l.Info("User has been added to the queue for creation", "username", u.Name)
+
 	return nil
 }
 
@@ -390,6 +392,8 @@ func (r *KafkaReconciler) handleDeleteUser(
 		return err
 	}
 
+	l.Info("User has been added to the queue for deletion", "username", u.Name)
+
 	return nil
 }
 
@@ -438,6 +442,8 @@ func (r *KafkaReconciler) detachUser(
 
 		return err
 	}
+
+	l.Info("User has been added to the queue for detaching", "username", u.Name)
 
 	return nil
 }

--- a/controllers/clusters/opensearch_controller.go
+++ b/controllers/clusters/opensearch_controller.go
@@ -990,6 +990,8 @@ func (r *OpenSearchReconciler) deleteUser(
 		return err
 	}
 
+	l.Info("User has been added to the queue for deletion", "username", u.Name)
+
 	return nil
 }
 
@@ -1046,6 +1048,8 @@ func (r *OpenSearchReconciler) createUser(
 			"Cannot add OpenSearch User to the cluster. Reason: %v", err)
 		return err
 	}
+
+	logger.Info("User has been added to the queue for creation", "username", u.Name)
 
 	return nil
 }

--- a/controllers/clusters/redis_controller.go
+++ b/controllers/clusters/redis_controller.go
@@ -442,6 +442,8 @@ func (r *RedisReconciler) handleCreateUsers(
 		return err
 	}
 
+	l.Info("User has been added to the queue for creation", "username", u.Name)
+
 	return nil
 }
 
@@ -793,6 +795,8 @@ func (r *RedisReconciler) handleUsersDelete(
 			"Cannot patch the Redis User status with the DeletingEvent. Reason: %v", err)
 		return err
 	}
+
+	l.Info("User has been added to the queue for deletion", "username", u.Name)
 
 	return nil
 }

--- a/pkg/instaclustr/errors.go
+++ b/pkg/instaclustr/errors.go
@@ -23,3 +23,5 @@ var (
 	NotFound                  = errors.New("not found")
 	ClusterIsNotReadyToResize = errors.New("cluster is not ready to resize yet")
 )
+
+const MsgDeleteUser = "If you want to delete the user, remove it from the clusters specifications first"

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -54,6 +54,6 @@ var (
 	ErrImmutableSecretRef                    = errors.New("secret reference is immutable")
 	ErrEmptySecretRef                        = errors.New("secretRef.name and secretRef.namespace should not be empty")
 	ErrMissingSecretKeys                     = errors.New("the secret is missing the correct keys for the user")
-	ErrUserStillExist                        = errors.New("the user is still attached to cluster")
+	ErrUserStillExist                        = errors.New("the user is still attached to the cluster. If you want to delete the user, remove the user from the cluster specification first")
 	ErrOnlyOneEntityTwoFactorDelete          = errors.New("currently only one entity of two factor delete can be filled")
 )

--- a/pkg/models/operator.go
+++ b/pkg/models/operator.go
@@ -27,7 +27,6 @@ const (
 	ClusterDeletionAnnotation = "instaclustr.com/clusterDeletion"
 	ExternalChangesAnnotation = "instaclustr.com/externalChanges"
 	DeletionFinalizer         = "instaclustr.com/deletionFinalizer"
-	DeletionUserFinalizer     = "instaclustr.com/dependsOnCluster_"
 	StartTimestampAnnotation  = "instaclustr.com/startTimestamp"
 	UpdateQueuedAnnotation    = "instaclustr.com/updateQueued"
 


### PR DESCRIPTION
- removed redundant finalizers in user functionality, which is set after each new cluster assignment.
- from now on we will use only one and only finalizer that is bound between a User CRD and the Secret.
- added a const containing a message for user deletion
- cleaned up a code
- moved the adding finalizers at the beginning of the reconcile func
- fixes along the way for some user controllers.
- Closes #532 
