### PR TITLE
integration tests for Cassandra User + Cassandra cluster

### DIFF
--- a/controllers/clusterresources/cassandrauser_controller.go
+++ b/controllers/clusterresources/cassandrauser_controller.go
@@ -157,7 +157,7 @@ func (r *CassandraUserReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		if event == models.DeletingEvent {
-			l.Info("Deleting user", "user", u, "cluster ID", clusterID)
+			l.Info("Deleting user from a cluster", "cluster ID", clusterID)
 
 			err = r.API.DeleteUser(username, clusterID, instaclustr.CassandraBundleUser)
 			if err != nil {

--- a/controllers/clusters/cassandra_controller.go
+++ b/controllers/clusters/cassandra_controller.go
@@ -600,9 +600,7 @@ func (r *CassandraReconciler) handleDeleteCluster(
 		"cluster name", cassandra.Spec.Name,
 		"cluster ID", cassandra.Status.ID,
 		"kind", cassandra.Kind,
-		"api Version", cassandra.APIVersion,
-		"namespace", cassandra.Namespace,
-	)
+		"api Version", cassandra.APIVersion)
 
 	r.EventRecorder.Eventf(
 		cassandra, models.Normal, models.Deleted,
@@ -627,7 +625,7 @@ func (r *CassandraReconciler) handleUsersCreate(
 	err := r.Get(ctx, req, u)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			l.Error(err, "Cassandra user is not found", "request", req)
+			l.Error(err, "Cannot create a Cassandra user. The resource is not found", "request", req)
 			r.EventRecorder.Eventf(c, models.Warning, models.NotFound,
 				"User is not found, create a new one Cassandra User or provide correct userRef."+
 					"Current provided reference: %v", uRef)
@@ -686,16 +684,15 @@ func (r *CassandraReconciler) handleUsersDelete(
 	err := r.Get(ctx, req, u)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			l.Error(err, "Cassandra user is not found", "request", req)
+			l.Error(err, "Cannot delete a Cassandra user, the user is not found", "request", req)
 			r.EventRecorder.Eventf(c, models.Warning, models.NotFound,
-				"User is not found, create a new one Cassandra User or provide correct userRef."+
-					"Current provided reference: %v", uRef)
-			return err
+				"Cannot delete a Cassandra user, the user %v is not found", req)
+			return nil
 		}
 
-		l.Error(err, "Cannot get Cassandra user", "user", u.Spec)
+		l.Error(err, "Cannot get Cassandra user", "user", req)
 		r.EventRecorder.Eventf(c, models.Warning, models.DeletionFailed,
-			"Cannot get Cassandra user. user reference: %v", uRef)
+			"Cannot get Cassandra user. user reference: %v", req)
 		return err
 	}
 
@@ -703,7 +700,7 @@ func (r *CassandraReconciler) handleUsersDelete(
 		l.Info("User is not existing on the cluster",
 			"user reference", uRef)
 		r.EventRecorder.Eventf(c, models.Normal, models.DeletionFailed,
-			"User is not existing on the cluster. User reference: %v", uRef)
+			"User is not existing on the cluster. User reference: %v", req)
 
 		return nil
 	}
@@ -721,7 +718,9 @@ func (r *CassandraReconciler) handleUsersDelete(
 		return err
 	}
 
-	l.Info("User has been added to the queue for deletion", "username", u.Name)
+	l.Info("User has been added to the queue for deletion",
+		"User resource", u.Namespace+"/"+u.Name,
+		"Cassandra resource", c.Namespace+"/"+c.Name)
 
 	return nil
 }
@@ -741,16 +740,15 @@ func (r *CassandraReconciler) handleUsersDetach(
 	err := r.Get(ctx, req, u)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			l.Error(err, "Cassandra user is not found", "request", req)
+			l.Error(err, "Cannot detach a Cassandra user, the user is not found", "request", req)
 			r.EventRecorder.Eventf(c, models.Warning, models.NotFound,
-				"User resource is not found, please provide correct userRef."+
-					"Current provided reference: %v", uRef)
-			return err
+				"Cannot detach a Cassandra user, the user %v is not found", req)
+			return nil
 		}
 
-		l.Error(err, "Cannot get Cassandra user", "user", u.Spec)
+		l.Error(err, "Cannot get Cassandra user", "user", req)
 		r.EventRecorder.Eventf(c, models.Warning, models.DeletionFailed,
-			"Cannot get Cassandra user. user reference: %v", uRef)
+			"Cannot get Cassandra user. user reference: %v", req)
 		return err
 	}
 

--- a/controllers/clusters/datatest/cassandra_v1beta1.yaml
+++ b/controllers/clusters/datatest/cassandra_v1beta1.yaml
@@ -2,6 +2,9 @@ apiVersion: clusters.instaclustr.com/v1beta1
 kind: Cassandra
 metadata:
   name: cassandra-cluster
+  namespace: default
+  annotations:
+    defaulter: webhook
 spec:
   name: "Cassandra"
   version: "3.11.13"

--- a/controllers/tests/cassandra_plus_users_test.go
+++ b/controllers/tests/cassandra_plus_users_test.go
@@ -19,13 +19,17 @@ package tests
 import (
 	"context"
 	"os"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/utils/strings/slices"
 
 	clusterresource "github.com/instaclustr/operator/apis/clusterresources/v1beta1"
@@ -38,17 +42,20 @@ var _ = Describe("Basic Cassandra User controller + Basic Cassandra cluster cont
 	var (
 		ns = "default"
 
-		user         clusterresource.CassandraUser
-		userManifest clusterresource.CassandraUser
+		user1         clusterresource.CassandraUser
+		user2         clusterresource.CassandraUser
+		userManifest1 clusterresource.CassandraUser
+		userManifest2 clusterresource.CassandraUser
 
 		secret         v1.Secret
 		secretManifest v1.Secret
 
-		cassandra         v1beta1.Cassandra
+		cassandra1        v1beta1.Cassandra
+		cassandra2        v1beta1.Cassandra
 		cassandraManifest v1beta1.Cassandra
 
-		timeout  = time.Second * 5
-		interval = time.Second * 2
+		timeout  = time.Millisecond * 300
+		interval = time.Millisecond * 100
 	)
 
 	ctx := context.Background()
@@ -56,10 +63,11 @@ var _ = Describe("Basic Cassandra User controller + Basic Cassandra cluster cont
 	cassandraUserYAML, err := os.ReadFile("datatest/clusterresources_v1beta1_cassandrauser.yaml")
 	Expect(err).NotTo(HaveOccurred())
 
-	err = yaml.Unmarshal(cassandraUserYAML, &userManifest)
+	err = yaml.Unmarshal(cassandraUserYAML, &userManifest1)
 	Expect(err).NotTo(HaveOccurred())
 
-	cassandraUserNS := types.NamespacedName{Name: userManifest.ObjectMeta.Name, Namespace: ns}
+	userNamespacedName1 := types.NamespacedName{Name: userManifest1.ObjectMeta.Name, Namespace: ns}
+	userNamespacedName2 := types.NamespacedName{}
 
 	secretYAML, err := os.ReadFile("datatest/secret.yaml")
 	Expect(err).NotTo(HaveOccurred())
@@ -75,15 +83,22 @@ var _ = Describe("Basic Cassandra User controller + Basic Cassandra cluster cont
 	err = yaml.Unmarshal(cassandraYAML, &cassandraManifest)
 	Expect(err).NotTo(HaveOccurred())
 
-	cassandraNS := types.NamespacedName{Name: cassandraManifest.ObjectMeta.Name, Namespace: ns}
+	cassandraManifest2 := cassandraManifest.DeepCopy()
+	cassandraManifest2.ObjectMeta.Name += "-2"
+	cassandraManifest2.Spec.Name += "-2"
+
+	cassandraNamespacedName1 := types.NamespacedName{Name: cassandraManifest.ObjectMeta.Name, Namespace: ns}
+	cassandraNamespacedName2 := types.NamespacedName{Name: cassandraManifest2.ObjectMeta.Name, Namespace: ns}
+
+	clusterID1 := cassandraManifest.Spec.Name + openapi.CreatedID
+	clusterID2 := cassandraManifest2.Spec.Name + openapi.CreatedID
 
 	When("apply a secret and a cassandra user manifests", func() {
-		It("should create both resources and they've got to have a link with themselves through finalizer", func() {
+		It("should create both resources and they've got to have a link them through a finalizer", func() {
 			Expect(k8sClient.Create(ctx, &secretManifest)).Should(Succeed())
-			Expect(k8sClient.Create(ctx, &userManifest)).Should(Succeed())
-
+			Expect(k8sClient.Create(ctx, &userManifest1)).Should(Succeed())
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, cassandraUserNS, &user); err != nil {
+				if err := k8sClient.Get(ctx, userNamespacedName1, &user1); err != nil {
 					return false
 				}
 
@@ -91,65 +106,53 @@ var _ = Describe("Basic Cassandra User controller + Basic Cassandra cluster cont
 					return false
 				}
 
-				if user.Finalizers == nil {
+				if user1.Finalizers == nil {
 					return false
 				}
 
-				uniqFinalizer := user.GetDeletionFinalizer()
+				uniqFinalizer := user1.GetDeletionFinalizer()
 
-				return slices.Contains(user.Finalizers, uniqFinalizer) || slices.Contains(secret.Finalizers, uniqFinalizer)
+				return slices.Contains(user1.Finalizers, uniqFinalizer) && slices.Contains(secret.Finalizers, uniqFinalizer)
 			}).Should(BeTrue())
 		})
 	})
 
 	When("apply a cassandra manifest", func() {
-		cassandraManifest.Annotations = map[string]string{models.ResourceStateAnnotation: models.CreatingEvent}
 		It("should create a cassandra resource", func() {
 			Expect(k8sClient.Create(ctx, &cassandraManifest)).Should(Succeed())
 
 			By("sending Cassandra specification to the Instaclustr API and get ID of a created cluster")
-
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, cassandraNS, &cassandra); err != nil {
+				if err := k8sClient.Get(ctx, cassandraNamespacedName1, &cassandra1); err != nil {
 					return false
 				}
 
-				return cassandra.Status.ID == openapi.CreatedID
+				return cassandra1.Status.ID == clusterID1
 			}).Should(BeTrue())
 		})
 	})
 
 	When("add the user to a Cassandra UserReference", func() {
-		newUsers := []*v1beta1.UserReference{{
-			Namespace: userManifest.Namespace,
-			Name:      userManifest.Name,
-		}}
-		cassandraNS := types.NamespacedName{Name: cassandraManifest.ObjectMeta.Name, Namespace: ns}
-		userNS := types.NamespacedName{Name: userManifest.ObjectMeta.Name, Namespace: ns}
-
 		It("should create the user for the cluster", func() {
+			newUsers := []*v1beta1.UserReference{{
+				Namespace: userManifest1.Namespace,
+				Name:      userManifest1.Name,
+			}}
 
-			Expect(k8sClient.Get(ctx, cassandraNS, &cassandra)).Should(Succeed())
+			Expect(k8sClient.Get(ctx, cassandraNamespacedName1, &cassandra1)).Should(Succeed())
 
-			patch := cassandra.NewPatch()
-			cassandra.Spec.UserRefs = newUsers
-
-			Expect(k8sClient.Patch(ctx, &cassandra, patch)).Should(Succeed())
-
+			patch := cassandra1.NewPatch()
+			// adding user
+			cassandra1.Spec.UserRefs = newUsers
+			Expect(k8sClient.Patch(ctx, &cassandra1, patch)).Should(Succeed())
 			By("going to Cassandra(cluster) controller predicate and put user entity to creation state. " +
 				"Finally creates the user for the corresponded cluster")
-
-			clusterID := cassandra.Status.ID
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, cassandraNS, &cassandra); err != nil {
+				if err := k8sClient.Get(ctx, userNamespacedName1, &user1); err != nil {
 					return false
 				}
 
-				if err := k8sClient.Get(ctx, userNS, &user); err != nil {
-					return false
-				}
-
-				if state, exist := user.Status.ClustersEvents[clusterID]; exist && state != models.Created {
+				if state, exist := user1.Status.ClustersEvents[clusterID1]; exist && state != models.Created {
 					return false
 				}
 
@@ -160,27 +163,20 @@ var _ = Describe("Basic Cassandra User controller + Basic Cassandra cluster cont
 
 	When("remove the user from the Cassandra UserReference", func() {
 		It("should delete the user for the cluster", func() {
-			Expect(k8sClient.Get(ctx, cassandraNS, &cassandra)).Should(Succeed())
+			Expect(k8sClient.Get(ctx, cassandraNamespacedName1, &cassandra1)).Should(Succeed())
 
-			patch := cassandra.NewPatch()
-			cassandra.Spec.UserRefs = []*v1beta1.UserReference{}
-
-			Expect(k8sClient.Patch(ctx, &cassandra, patch)).Should(Succeed())
-
+			patch := cassandra1.NewPatch()
+			// removing user
+			cassandra1.Spec.UserRefs = []*v1beta1.UserReference{}
+			Expect(k8sClient.Patch(ctx, &cassandra1, patch)).Should(Succeed())
 			By("going to Cassandra(cluster) controller predicate and put user entity to deletion state. " +
 				"Finally deletes the user for the corresponded cluster")
-
-			clusterID := cassandra.Status.ID
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, cassandraNS, &cassandra); err != nil {
+				if err := k8sClient.Get(ctx, userNamespacedName1, &user1); err != nil {
 					return false
 				}
 
-				if err := k8sClient.Get(ctx, cassandraUserNS, &user); err != nil {
-					return false
-				}
-
-				if _, exist := user.Status.ClustersEvents[clusterID]; exist {
+				if _, exist := user1.Status.ClustersEvents[clusterID1]; exist {
 					return false
 				}
 
@@ -188,4 +184,234 @@ var _ = Describe("Basic Cassandra User controller + Basic Cassandra cluster cont
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
+
+	Context("Create multiple users for the cluster", func() {
+		Specify("our users", func() {
+			secretManifest2 := v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secret.Name + "-2",
+					Namespace: ns,
+				},
+				StringData: map[string]string{
+					"username": "carlo",
+					"password": "qwerty123",
+				},
+			}
+			Expect(k8sClient.Create(ctx, &secretManifest2)).Should(Succeed())
+
+			userManifest2 = clusterresource.CassandraUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      userManifest1.Name + "-2",
+					Namespace: ns,
+				},
+				Spec: clusterresource.CassandraUserSpec{
+					SecretRef: &clusterresource.SecretReference{
+						Name:      secretManifest2.Name,
+						Namespace: secretManifest2.Namespace,
+					}},
+			}
+			Expect(k8sClient.Create(ctx, &userManifest2)).Should(Succeed())
+
+			By("adding the batch of users to the cluster, Cassandra(cluster) controller predicate set them creation state")
+			newUsers := []*v1beta1.UserReference{
+				{
+					Namespace: userManifest1.Namespace,
+					Name:      userManifest1.Name,
+				},
+				{
+					Namespace: userManifest2.Namespace,
+					Name:      userManifest2.Name,
+				},
+			}
+
+			Expect(k8sClient.Get(ctx, cassandraNamespacedName1, &cassandra1)).Should(Succeed())
+
+			patch := cassandra1.NewPatch()
+			cassandra1.Spec.UserRefs = newUsers
+			Expect(k8sClient.Patch(ctx, &cassandra1, patch)).Should(Succeed())
+
+			userNamespacedName2 = types.NamespacedName{Name: userManifest2.ObjectMeta.Name, Namespace: ns}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, userNamespacedName1, &user1); err != nil {
+					return false
+				}
+				if state, exist := user1.Status.ClustersEvents[clusterID1]; exist && state != models.Created {
+					return false
+				}
+
+				if err := k8sClient.Get(ctx, userNamespacedName2, &user2); err != nil {
+					return false
+				}
+				if state, exist := user2.Status.ClustersEvents[clusterID1]; exist && state != models.Created {
+					return false
+				}
+
+				return true
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	When("adding new user with exactly same spec (Secret reference)", func() {
+		userManifest3 := &clusterresource.CassandraUser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      userManifest1.Name + "-3",
+				Namespace: ns,
+			},
+			Spec: *userManifest1.Spec.DeepCopy(),
+		}
+		It("makes sure that several users may be added to one Secret and "+
+			"the Secret has reference on each user respectively", func() {
+			Expect(k8sClient.Create(ctx, userManifest3)).Should(Succeed())
+
+			user3 := clusterresource.CassandraUser{}
+			userNamespacedName3 := types.NamespacedName{Name: userManifest3.ObjectMeta.Name, Namespace: ns}
+
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, userNamespacedName1, &user1); err != nil {
+					return false
+				}
+
+				if err := k8sClient.Get(ctx, userNamespacedName3, &user3); err != nil {
+					return false
+				}
+
+				if err := k8sClient.Get(ctx, secretNS, &secret); err != nil {
+					return false
+				}
+
+				if user1.Finalizers == nil {
+					return false
+				}
+
+				uniqFinalizer := user1.GetDeletionFinalizer()
+				uniqFinalizer3 := user3.GetDeletionFinalizer()
+
+				return slices.Contains(user1.Finalizers, uniqFinalizer) && slices.Contains(secret.Finalizers, uniqFinalizer) &&
+					slices.Contains(user3.Finalizers, uniqFinalizer3) && slices.Contains(secret.Finalizers, uniqFinalizer3)
+			}).Should(BeTrue())
+		})
+	})
+
+	When("attempting to delete a User entity that is currently associated with a cluster, an error should be returned", func() {
+		It("indicates that the user reference needs to be removed from the attached cluster before deletion can proceed", func() {
+			Expect(k8sClient.Get(ctx, userNamespacedName2, &user2)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &user2)).Should(Succeed())
+
+			// wait until send a request and receive the error
+			time.Sleep(interval)
+
+			events, err := core.NewForConfigOrDie(cfg).Events("default").
+				List(context.TODO(), metav1.ListOptions{
+					TypeMeta: metav1.TypeMeta{
+						Kind: user2.Kind,
+					},
+					FieldSelector: "involvedObject.name=" + user2.Name,
+				})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("iterating through the user events' messages, we assert that the user has not been deleted yet. " +
+				"a warning is returned indicating a lingering cluster reference")
+			errMsg := "remove it from the clusters specifications first"
+
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, userNamespacedName2, &user2); err != nil {
+					return false
+				}
+
+				for _, item := range events.Items {
+					if strings.Contains(item.Message, errMsg) {
+						return true
+					}
+				}
+
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+		})
+	})
+
+	When("choosing to continue working with a user in a deletion state and adding them to a new cluster", func() {
+		It("should proceed smoothly without encountering any issues", func() {
+			Expect(k8sClient.Get(ctx, userNamespacedName2, &user2)).Should(Succeed())
+			By("creating another Cassandra cluster manifest with filled user ref, " +
+				"we make sure the user creation job works properly and show us that the user is available for use")
+			newUsers := []*v1beta1.UserReference{{
+				Namespace: user2.Namespace,
+				Name:      user2.Name,
+			}}
+
+			cassandraManifest2.Spec.UserRefs = newUsers
+			Expect(k8sClient.Create(ctx, cassandraManifest2)).Should(Succeed())
+
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, cassandraNamespacedName2, &cassandra2); err != nil {
+					return false
+				}
+
+				if cassandra2.Status.ID != clusterID2 {
+					return false
+				}
+
+				if err := k8sClient.Get(ctx, userNamespacedName2, &user2); err != nil {
+					return false
+				}
+
+				if event, exist := user2.Status.ClustersEvents[clusterID2]; exist && event != models.Created {
+					return false
+				}
+
+				return true
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	When("remove the user, which is in a deletion state, from cluster with multiple users", func() {
+		It("sends delete user request to user controller", func() {
+			Expect(k8sClient.Get(ctx, userNamespacedName2, &user2)).Should(Succeed())
+			Expect(k8sClient.Get(ctx, cassandraNamespacedName1, &cassandra1)).Should(Succeed())
+			patch := cassandra1.NewPatch()
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, userNamespacedName2, &user2); err != nil {
+					return false
+				}
+
+				for i := range cassandra1.Spec.UserRefs {
+					if user2.Name == cassandra1.Spec.UserRefs[i].Name && user2.Namespace == cassandra1.Spec.UserRefs[i].Namespace {
+						cassandra1.Spec.UserRefs = removeUserByIndex(cassandra1.Spec.UserRefs, i)
+						Expect(k8sClient.Patch(ctx, &cassandra1, patch)).Should(Succeed())
+					}
+				}
+
+				if err := k8sClient.Get(ctx, userNamespacedName2, &user2); err != nil {
+					return false
+				}
+
+				if _, exist := user2.Status.ClustersEvents[clusterID2]; exist {
+					return false
+				}
+
+				return true
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	When("deleting a cluster to which (deleting) user is attached", func() {
+		It("sends detaching queue to User controller. Since the user has been marked for deletion and "+
+			"no longer has any attachments to clusters, the user is subsequently scheduled for deletion", func() {
+			Expect(k8sClient.Get(ctx, cassandraNamespacedName2, &cassandra2)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &cassandra2)).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, userNamespacedName2, &user2)
+				if err != nil && !k8serrors.IsNotFound(err) {
+					return false
+				}
+
+				return k8serrors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
 })
+
+func removeUserByIndex(s []*v1beta1.UserReference, index int) []*v1beta1.UserReference {
+	return append(s[:index], s[index+1:]...)
+}

--- a/controllers/tests/datatest/clusters_v1beta1_cassandra.yaml
+++ b/controllers/tests/datatest/clusters_v1beta1_cassandra.yaml
@@ -3,6 +3,8 @@ kind: Cassandra
 metadata:
   name: cassandra-sample
   namespace: default
+  annotations:
+    defaulter: webhook
 spec:
   name: "Cassandra"
   version: "3.11.13"

--- a/controllers/tests/suite_test.go
+++ b/controllers/tests/suite_test.go
@@ -94,9 +94,10 @@ var _ = BeforeSuite(func() {
 
 	eRecorder := k8sManager.GetEventRecorderFor("instaclustr-operator-tests")
 
-	scheduler.ClusterStatusInterval = 1 * time.Second
-	scheduler.ClusterBackupsInterval = 30 * time.Second
-	models.ReconcileRequeue = reconcile.Result{RequeueAfter: time.Second * 3}
+	scheduler.ClusterStatusInterval = time.Millisecond * 100
+	scheduler.ClusterBackupsInterval = time.Second * 30
+	scheduler.UserCreationInterval = time.Millisecond * 100
+	models.ReconcileRequeue = reconcile.Result{RequeueAfter: time.Millisecond * 100}
 
 	err = (&clusters.CassandraReconciler{
 		Client:        k8sManager.GetClient(),


### PR DESCRIPTION
- Improved log messages
- Cleaned up an existing integration test for Cassandra cluster functionality.
- Added extensive cases for Cassandra User and Cassandra cluster controller interaction
- Tested the User creation job
- Tested multi-user addition, deletion, and detachment
- Validated behavior of a user in a deletion state, confirming their ability to persist while remaining attached to a single secret. This test covers the recent functionality update with the removal of several finalizers after each new cluster attachment.
- Tested one and several users on several clusters.
- Tested several users on one secret.
- Cleaned up and improved test logic of an existing integration test for Cassandra cluster + Cassandra user functionality.
- Refactored handlers and service of Cassandra cluster in Instaclustr stub server