### PR TITLE
hot fix for deleting and detaching a not found user

### DIFF
--- a/controllers/clusters/kafka_controller.go
+++ b/controllers/clusters/kafka_controller.go
@@ -360,7 +360,7 @@ func (r *KafkaReconciler) handleDeleteUser(
 			r.EventRecorder.Event(kafka, models.Warning, "Not Found",
 				"User is not found, please provide correct userRef.")
 
-			return err
+			return nil
 		}
 
 		l.Error(err, "Cannot get Kafka user", "user", u.Spec)
@@ -415,7 +415,7 @@ func (r *KafkaReconciler) detachUser(
 			r.EventRecorder.Event(kafka, models.Warning, "Not Found",
 				"User is not found, please provide correct userRef.")
 
-			return err
+			return nil
 		}
 
 		l.Error(err, "Cannot get Kafka user", "user", u.Spec)

--- a/controllers/clusters/opensearch_controller.go
+++ b/controllers/clusters/opensearch_controller.go
@@ -961,7 +961,7 @@ func (r *OpenSearchReconciler) deleteUser(
 			r.EventRecorder.Eventf(c, models.Warning, models.NotFound,
 				"User resource is not found, please provide correct userRef."+
 					"Current provided reference: %v", uRef)
-			return err
+			return nil
 		}
 
 		l.Error(err, "Cannot get OpenSearch user", "user", u.Spec)
@@ -1073,7 +1073,7 @@ func (r *OpenSearchReconciler) detachUserResource(
 			r.EventRecorder.Eventf(c, models.Warning, models.NotFound,
 				"User resource is not found, please provide correct userRef."+
 					"Current provided reference: %v", uRef)
-			return err
+			return nil
 		}
 
 		l.Error(err, "Cannot get OpenSearch user", "user", u.Spec)

--- a/controllers/clusters/redis_controller.go
+++ b/controllers/clusters/redis_controller.go
@@ -661,7 +661,7 @@ func (r *RedisReconciler) detachUserResource(
 			r.EventRecorder.Eventf(redis, models.Warning, models.NotFound,
 				"User resource is not found, please provide correct userRef."+
 					"Current provided reference: %v", uRef)
-			return err
+			return nil
 		}
 
 		l.Error(err, "Cannot get Redis user", "user", u.Spec)
@@ -765,7 +765,7 @@ func (r *RedisReconciler) handleUsersDelete(
 			r.EventRecorder.Eventf(c, models.Warning, models.NotFound,
 				"User is not found, create a new one Redis User or provide correct userRef."+
 					"Current provided reference: %v", uRef)
-			return err
+			return nil
 		}
 
 		l.Error(err, "Cannot get Redis user", "user", u.Spec)


### PR DESCRIPTION
Fixed a case where a user could not be removed from the cluster if it was not created/notFound in Kubernetes cluster.