### PR TITLE
Fix failed job. Refreshed integration tests

### DIFF
--- a/controllers/clusters/cassandra_controller_test.go
+++ b/controllers/clusters/cassandra_controller_test.go
@@ -19,7 +19,6 @@ package clusters
 import (
 	"context"
 	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -28,22 +27,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/instaclustr/operator/apis/clusters/v1beta1"
+	"github.com/instaclustr/operator/controllers/tests"
 	openapi "github.com/instaclustr/operator/pkg/instaclustr/mock/server/go"
-	"github.com/instaclustr/operator/pkg/models"
 )
 
 const newCassandraNodeSize = "CAS-DEV-t4g.small-30"
 
 var _ = Describe("Cassandra Controller", func() {
-	var (
-		ns = "default"
-
-		cassandra         v1beta1.Cassandra
-		cassandraManifest v1beta1.Cassandra
-
-		timeout  = time.Second * 40
-		interval = time.Second * 2
-	)
+	cassandra := v1beta1.Cassandra{}
+	cassandraManifest := v1beta1.Cassandra{}
 
 	yfile, err := os.ReadFile("datatest/cassandra_v1beta1.yaml")
 	Expect(err).NotTo(HaveOccurred())
@@ -54,37 +46,37 @@ var _ = Describe("Cassandra Controller", func() {
 	ctx := context.Background()
 
 	clusterID := cassandraManifest.Spec.Name + openapi.CreatedID
-	cassandraNamespacedName := types.NamespacedName{Name: cassandraManifest.ObjectMeta.Name, Namespace: ns}
+	cassandraNamespacedName := types.NamespacedName{Name: cassandraManifest.ObjectMeta.Name, Namespace: defaultNS}
 
 	When("apply a cassandra manifest", func() {
 		It("should create a cassandra resources", func() {
 			Expect(k8sClient.Create(ctx, &cassandraManifest)).Should(Succeed())
+
+			done := tests.NewChannelWithTimeout(timeout)
+
 			By("sending cassandra specification to the Instaclustr API and get ID of created cluster.")
-
 			Eventually(func() bool {
-
 				if err := k8sClient.Get(ctx, cassandraNamespacedName, &cassandra); err != nil {
 					return false
 				}
 
 				return cassandra.Status.ID == clusterID
 			}).Should(BeTrue())
+
+			<-done
 		})
 	})
 
 	When("changing a node size", func() {
 		It("should update a cassandra resources", func() {
 			Expect(k8sClient.Get(ctx, cassandraNamespacedName, &cassandra)).Should(Succeed())
+
 			patch := cassandra.NewPatch()
-
 			cassandra.Spec.DataCentres[0].NodeSize = newCassandraNodeSize
-
-			cassandra.Annotations = map[string]string{models.ResourceStateAnnotation: models.UpdatingEvent}
 			Expect(k8sClient.Patch(ctx, &cassandra, patch)).Should(Succeed())
 
 			By("sending a resize request to the Instaclustr API. And when the resize is completed, " +
 				"the status job get new data from the InstAPI and update it in k8s cassandra resource")
-
 			Eventually(func() bool {
 				if err := k8sClient.Get(ctx, cassandraNamespacedName, &cassandra); err != nil {
 					return false
@@ -102,11 +94,7 @@ var _ = Describe("Cassandra Controller", func() {
 	When("delete the cassandra resource", func() {
 		It("should send delete request to the Instaclustr API", func() {
 			Expect(k8sClient.Get(ctx, cassandraNamespacedName, &cassandra)).Should(Succeed())
-
-			cassandra.Annotations = map[string]string{models.ResourceStateAnnotation: models.DeletingEvent}
-
 			Expect(k8sClient.Delete(ctx, &cassandra)).Should(Succeed())
-
 			By("sending delete request to Instaclustr API")
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, cassandraNamespacedName, &cassandra)
@@ -114,7 +102,7 @@ var _ = Describe("Cassandra Controller", func() {
 					return false
 				}
 
-				return true
+				return k8serrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/controllers/clusters/datatest/kafka_v1beta1.yaml
+++ b/controllers/clusters/datatest/kafka_v1beta1.yaml
@@ -2,6 +2,9 @@ apiVersion: clusters.instaclustr.com/v1beta1
 kind: Kafka
 metadata:
   name: kafka
+  namespace: default
+  annotations:
+    defaulter: webhook
 spec:
   name: "kafka"
   version: "2.8.2"

--- a/controllers/clusters/datatest/kafkaconnect_v1beta1.yaml
+++ b/controllers/clusters/datatest/kafkaconnect_v1beta1.yaml
@@ -2,6 +2,9 @@ apiVersion: clusters.instaclustr.com/v1beta1
 kind: KafkaConnect
 metadata:
   name: kafkaconnect-sample
+  namespace: default
+  annotations:
+    defaulter: webhook
 spec:
   dataCentres:
     - name: "US_EAST_1_DC_KAFKA"

--- a/controllers/clusters/datatest/opensearch_v1beta1.yaml
+++ b/controllers/clusters/datatest/opensearch_v1beta1.yaml
@@ -2,6 +2,9 @@ apiVersion: clusters.instaclustr.com/v1beta1
 kind: OpenSearch
 metadata:
   name: opensearch
+  namespace: default
+  annotations:
+    defaulter: webhook
 spec:
   alertingPlugin: false
   anomalyDetectionPlugin: false

--- a/controllers/clusters/datatest/postgresql_v1beta1.yaml
+++ b/controllers/clusters/datatest/postgresql_v1beta1.yaml
@@ -2,6 +2,7 @@ apiVersion: clusters.instaclustr.com/v1beta1
 kind: PostgreSQL
 metadata:
   name: postgresql-sample
+  namespace: default
   annotations:
     testAnnotation: test
 spec:

--- a/controllers/clusters/datatest/redis_v1beta1.yaml
+++ b/controllers/clusters/datatest/redis_v1beta1.yaml
@@ -2,12 +2,14 @@ apiVersion: clusters.instaclustr.com/v1beta1
 kind: Redis
 metadata:
   name: redis-sample
+  namespace: default
+  annotations:
+    defaulter: webhook
 spec:
   name: "testRedis"
   version: "7.0.5"
   slaTier: "NON_PRODUCTION"
   pciCompliance: true
-  concurrentResizes: 1
   clientToNodeEncryption: true
   privateNetworkCluster: true
   notifySupportContacts: true

--- a/controllers/clusters/datatest/zookeeper_v1beta1.yaml
+++ b/controllers/clusters/datatest/zookeeper_v1beta1.yaml
@@ -2,6 +2,9 @@ apiVersion: clusters.instaclustr.com/v1beta1
 kind: Zookeeper
 metadata:
   name: zookeeper-sample
+  namespace: default
+  annotations:
+    defaulter: webhook
 spec:
   dataCentres:
     - clientToServerEncryption: true

--- a/controllers/clusters/kafka_controller_test.go
+++ b/controllers/clusters/kafka_controller_test.go
@@ -19,109 +19,88 @@ package clusters
 import (
 	"context"
 	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/instaclustr/operator/apis/clusters/v1beta1"
+	"github.com/instaclustr/operator/controllers/tests"
 	openapi "github.com/instaclustr/operator/pkg/instaclustr/mock/server/go"
-	"github.com/instaclustr/operator/pkg/models"
 )
 
 const newKafkaNodeSize = "KFK-DEV-t4g.medium-80"
 
 var _ = Describe("Kafka Controller", func() {
-	var (
-		kafkaResource v1beta1.Kafka
-		kafkaYAML     v1beta1.Kafka
-		k             = "kafka"
-		ns            = "default"
-		kafkaNS       = types.NamespacedName{Name: k, Namespace: ns}
-		timeout       = time.Second * 40
-		interval      = time.Second * 2
-	)
+	kafka := v1beta1.Kafka{}
+	kafkaManifest := v1beta1.Kafka{}
 
 	yfile, err := os.ReadFile("datatest/kafka_v1beta1.yaml")
 	Expect(err).NotTo(HaveOccurred())
 
-	err = yaml.Unmarshal(yfile, &kafkaYAML)
+	err = yaml.Unmarshal(yfile, &kafkaManifest)
 	Expect(err).NotTo(HaveOccurred())
 
-	kafkaObjMeta := metav1.ObjectMeta{
-		Name:      k,
-		Namespace: ns,
-		Annotations: map[string]string{
-			models.ResourceStateAnnotation: models.CreatingEvent,
-		},
-	}
-
-	kafkaYAML.ObjectMeta = kafkaObjMeta
+	kafkaNamespacedName := types.NamespacedName{Name: kafkaManifest.ObjectMeta.Name, Namespace: defaultNS}
 
 	ctx := context.Background()
 
 	When("apply a Kafka manifest", func() {
 		It("should create a Kafka resources", func() {
-			Expect(k8sClient.Create(ctx, &kafkaYAML)).Should(Succeed())
-			By("sending Kafka specification to the Instaclustr API and get ID of created cluster.")
+			Expect(k8sClient.Create(ctx, &kafkaManifest)).Should(Succeed())
+			done := tests.NewChannelWithTimeout(timeout)
 
+			By("sending Kafka specification to the Instaclustr API and get ID of created cluster.")
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, kafkaNS, &kafkaResource); err != nil {
+				if err := k8sClient.Get(ctx, kafkaNamespacedName, &kafka); err != nil {
 					return false
 				}
 
-				return kafkaResource.Status.ID == openapi.CreatedID
+				return kafka.Status.ID == openapi.CreatedID
 			}).Should(BeTrue())
+
+			<-done
 		})
 	})
 
 	When("changing a node size", func() {
 		It("should update a Kafka resources", func() {
-			Expect(k8sClient.Get(ctx, kafkaNS, &kafkaResource)).Should(Succeed())
-			patch := kafkaResource.NewPatch()
+			Expect(k8sClient.Get(ctx, kafkaNamespacedName, &kafka)).Should(Succeed())
 
-			kafkaResource.Spec.DataCentres[0].NodeSize = newKafkaNodeSize
-
-			kafkaResource.Annotations = map[string]string{models.ResourceStateAnnotation: models.UpdatingEvent}
-			Expect(k8sClient.Patch(ctx, &kafkaResource, patch)).Should(Succeed())
+			patch := kafka.NewPatch()
+			kafka.Spec.DataCentres[0].NodeSize = newKafkaNodeSize
+			Expect(k8sClient.Patch(ctx, &kafka, patch)).Should(Succeed())
 
 			By("sending a resize request to the Instaclustr API. And when the resize is completed, " +
 				"the status job get new data from the InstAPI and update it in k8s Kafka resource")
-
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, kafkaNS, &kafkaResource); err != nil {
+				if err := k8sClient.Get(ctx, kafkaNamespacedName, &kafka); err != nil {
 					return false
 				}
 
-				if len(kafkaResource.Status.DataCentres) == 0 || len(kafkaResource.Status.DataCentres[0].Nodes) == 0 {
+				if len(kafka.Status.DataCentres) == 0 || len(kafka.Status.DataCentres[0].Nodes) == 0 {
 					return false
 				}
 
-				return kafkaResource.Status.DataCentres[0].Nodes[0].Size == newKafkaNodeSize
+				return kafka.Status.DataCentres[0].Nodes[0].Size == newKafkaNodeSize
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
 
 	When("delete the Kafka resource", func() {
 		It("should send delete request to the Instaclustr API", func() {
-			Expect(k8sClient.Get(ctx, kafkaNS, &kafkaResource)).Should(Succeed())
-
-			kafkaResource.Annotations = map[string]string{models.ResourceStateAnnotation: models.DeletingEvent}
-
-			Expect(k8sClient.Delete(ctx, &kafkaResource)).Should(Succeed())
-
+			Expect(k8sClient.Get(ctx, kafkaNamespacedName, &kafka)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &kafka)).Should(Succeed())
 			By("sending delete request to Instaclustr API")
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, kafkaNS, &kafkaResource)
+				err := k8sClient.Get(ctx, kafkaNamespacedName, &kafka)
 				if err != nil && !k8serrors.IsNotFound(err) {
 					return false
 				}
 
-				return true
+				return k8serrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/controllers/clusters/kafkaconnect_controller_test.go
+++ b/controllers/clusters/kafkaconnect_controller_test.go
@@ -19,109 +19,83 @@ package clusters
 import (
 	"context"
 	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/instaclustr/operator/apis/clusters/v1beta1"
 	openapi "github.com/instaclustr/operator/pkg/instaclustr/mock/server/go"
-	"github.com/instaclustr/operator/pkg/models"
 )
 
 const newKafkaConnectNodeNumbers = 6
 
 var _ = Describe("Kafka Connect Controller", func() {
-	var (
-		kafkaResource v1beta1.KafkaConnect
-		kafkaYAML     v1beta1.KafkaConnect
-		kc            = "kafkaconnect"
-		ns            = "default"
-		kafkaNS       = types.NamespacedName{Name: kc, Namespace: ns}
-		timeout       = time.Second * 40
-		interval      = time.Second * 2
-	)
+	kafkaConnect := v1beta1.KafkaConnect{}
+	kafkaConnectManifest := v1beta1.KafkaConnect{}
 
 	yfile, err := os.ReadFile("datatest/kafkaconnect_v1beta1.yaml")
 	Expect(err).NotTo(HaveOccurred())
 
-	err = yaml.Unmarshal(yfile, &kafkaYAML)
+	err = yaml.Unmarshal(yfile, &kafkaConnectManifest)
 	Expect(err).NotTo(HaveOccurred())
 
-	kafkaObjMeta := metav1.ObjectMeta{
-		Name:      kc,
-		Namespace: ns,
-		Annotations: map[string]string{
-			models.ResourceStateAnnotation: models.CreatingEvent,
-		},
-	}
-
-	kafkaYAML.ObjectMeta = kafkaObjMeta
+	kafkaConnectNamespacedName := types.NamespacedName{Name: kafkaConnectManifest.ObjectMeta.Name, Namespace: defaultNS}
 
 	ctx := context.Background()
 
 	When("apply a Kafka Connect manifest", func() {
 		It("should create a Kafka Connect resources", func() {
-			Expect(k8sClient.Create(ctx, &kafkaYAML)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, &kafkaConnectManifest)).Should(Succeed())
 			By("sending Kafka Connect specification to the Instaclustr API and get ID of created cluster.")
-
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, kafkaNS, &kafkaResource); err != nil {
+				if err := k8sClient.Get(ctx, kafkaConnectNamespacedName, &kafkaConnect); err != nil {
 					return false
 				}
 
-				return kafkaResource.Status.ID == openapi.CreatedID
+				return kafkaConnect.Status.ID == openapi.CreatedID
 			}).Should(BeTrue())
 		})
 	})
 
 	When("changing a node size", func() {
 		It("should update a Kafka Connect resources", func() {
-			Expect(k8sClient.Get(ctx, kafkaNS, &kafkaResource)).Should(Succeed())
-			patch := kafkaResource.NewPatch()
+			Expect(k8sClient.Get(ctx, kafkaConnectNamespacedName, &kafkaConnect)).Should(Succeed())
 
-			kafkaResource.Spec.DataCentres[0].NodesNumber = newKafkaConnectNodeNumbers
-
-			kafkaResource.Annotations = map[string]string{models.ResourceStateAnnotation: models.UpdatingEvent}
-			Expect(k8sClient.Patch(ctx, &kafkaResource, patch)).Should(Succeed())
+			patch := kafkaConnect.NewPatch()
+			kafkaConnect.Spec.DataCentres[0].NodesNumber = newKafkaConnectNodeNumbers
+			Expect(k8sClient.Patch(ctx, &kafkaConnect, patch)).Should(Succeed())
 
 			By("sending a resize request to the Instaclustr API. And when the resize is completed, " +
 				"the status job get new data from the InstAPI and update it in k8s Kafka resource")
-
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, kafkaNS, &kafkaResource); err != nil {
+				if err := k8sClient.Get(ctx, kafkaConnectNamespacedName, &kafkaConnect); err != nil {
 					return false
 				}
 
-				if len(kafkaResource.Status.DataCentres) == 0 {
+				if len(kafkaConnect.Status.DataCentres) == 0 {
 					return false
 				}
 
-				return kafkaResource.Status.DataCentres[0].NodeNumber == newKafkaConnectNodeNumbers
+				return kafkaConnect.Status.DataCentres[0].NodeNumber == newKafkaConnectNodeNumbers
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
 
 	When("delete the Kafka Connect resource", func() {
 		It("should send delete request to the Instaclustr API", func() {
-			Expect(k8sClient.Get(ctx, kafkaNS, &kafkaResource)).Should(Succeed())
-
-			kafkaResource.Annotations = map[string]string{models.ResourceStateAnnotation: models.DeletingEvent}
-
-			Expect(k8sClient.Delete(ctx, &kafkaResource)).Should(Succeed())
-
+			Expect(k8sClient.Get(ctx, kafkaConnectNamespacedName, &kafkaConnect)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &kafkaConnect)).Should(Succeed())
 			By("sending delete request to Instaclustr API")
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, kafkaNS, &kafkaResource)
+				err := k8sClient.Get(ctx, kafkaConnectNamespacedName, &kafkaConnect)
 				if err != nil && !k8serrors.IsNotFound(err) {
 					return false
 				}
 
-				return true
+				return k8serrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/controllers/clusters/opensearch_controller_test.go
+++ b/controllers/clusters/opensearch_controller_test.go
@@ -19,105 +19,85 @@ package clusters
 import (
 	"context"
 	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/instaclustr/operator/apis/clusters/v1beta1"
+	"github.com/instaclustr/operator/controllers/tests"
 	openapi "github.com/instaclustr/operator/pkg/instaclustr/mock/server/go"
-	"github.com/instaclustr/operator/pkg/models"
 )
 
 const newOpenSearchNodeSize = "SRH-DEV-t4g.small-30"
 
 var _ = Describe("OpenSearch Controller", func() {
-	var (
-		openSearchResource v1beta1.OpenSearch
-		openSearchYAML     v1beta1.OpenSearch
-		o                  = "opensearch"
-		ns                 = "default"
-		openSearchNS       = types.NamespacedName{Name: o, Namespace: ns}
-		timeout            = time.Second * 40
-		interval           = time.Second * 2
-	)
+	openSearch := v1beta1.OpenSearch{}
+	openSearchManifest := v1beta1.OpenSearch{}
 
 	yfile, err := os.ReadFile("datatest/opensearch_v1beta1.yaml")
 	Expect(err).NotTo(HaveOccurred())
 
-	err = yaml.Unmarshal(yfile, &openSearchYAML)
+	err = yaml.Unmarshal(yfile, &openSearchManifest)
 	Expect(err).NotTo(HaveOccurred())
 
-	openSearchObjMeta := metav1.ObjectMeta{
-		Name:      o,
-		Namespace: ns,
-		Annotations: map[string]string{
-			models.ResourceStateAnnotation: models.CreatingEvent,
-		},
-	}
-
-	openSearchYAML.ObjectMeta = openSearchObjMeta
+	openSearchNamespacedName := types.NamespacedName{Name: openSearchManifest.ObjectMeta.Name, Namespace: defaultNS}
 
 	ctx := context.Background()
 
 	When("apply a OpenSearch manifest", func() {
 		It("should create a OpenSearch resources", func() {
-			Expect(k8sClient.Create(ctx, &openSearchYAML)).Should(Succeed())
-			By("sending OpenSearch specification to the Instaclustr API and get ID of created cluster.")
+			Expect(k8sClient.Create(ctx, &openSearchManifest)).Should(Succeed())
+			done := tests.NewChannelWithTimeout(timeout)
 
+			By("sending OpenSearch specification to the Instaclustr API and get ID of created cluster.")
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, openSearchNS, &openSearchResource); err != nil {
+				if err := k8sClient.Get(ctx, openSearchNamespacedName, &openSearch); err != nil {
 					return false
 				}
 
-				return openSearchResource.Status.ID == openapi.CreatedID
+				return openSearch.Status.ID == openapi.CreatedID
 			}).Should(BeTrue())
+
+			<-done
 		})
 	})
 
 	When("changing a node size", func() {
 		It("should update a OpenSearch resources", func() {
-			Expect(k8sClient.Get(ctx, openSearchNS, &openSearchResource)).Should(Succeed())
-			patch := openSearchResource.NewPatch()
+			Expect(k8sClient.Get(ctx, openSearchNamespacedName, &openSearch)).Should(Succeed())
 
-			openSearchResource.Spec.ClusterManagerNodes[0].NodeSize = newOpenSearchNodeSize
-
-			openSearchResource.Annotations = map[string]string{models.ResourceStateAnnotation: models.UpdatingEvent}
-			Expect(k8sClient.Patch(ctx, &openSearchResource, patch)).Should(Succeed())
+			patch := openSearch.NewPatch()
+			openSearch.Spec.ClusterManagerNodes[0].NodeSize = newOpenSearchNodeSize
+			Expect(k8sClient.Patch(ctx, &openSearch, patch)).Should(Succeed())
 
 			By("sending a resize request to the Instaclustr API. And when the resize is completed, " +
 				"the status job get new data from the InstAPI and update it in k8s OpenSearch resource")
-
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, openSearchNS, &openSearchResource); err != nil {
+				if err := k8sClient.Get(ctx, openSearchNamespacedName, &openSearch); err != nil {
 					return false
 				}
 
-				return openSearchResource.Spec.ClusterManagerNodes[0].NodeSize == newOpenSearchNodeSize
+				return openSearch.Spec.ClusterManagerNodes[0].NodeSize == newOpenSearchNodeSize
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
 
 	When("delete the OpenSearch resource", func() {
 		It("should send delete request to the Instaclustr API", func() {
-			Expect(k8sClient.Get(ctx, openSearchNS, &openSearchResource)).Should(Succeed())
-
-			openSearchResource.Annotations = map[string]string{models.ResourceStateAnnotation: models.DeletingEvent}
-
-			Expect(k8sClient.Delete(ctx, &openSearchResource)).Should(Succeed())
+			Expect(k8sClient.Get(ctx, openSearchNamespacedName, &openSearch)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &openSearch)).Should(Succeed())
 
 			By("sending delete request to Instaclustr API")
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, openSearchNS, &openSearchResource)
+				err := k8sClient.Get(ctx, openSearchNamespacedName, &openSearch)
 				if err != nil && !k8serrors.IsNotFound(err) {
 					return false
 				}
 
-				return true
+				return k8serrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/controllers/clusters/redis_controller_test.go
+++ b/controllers/clusters/redis_controller_test.go
@@ -19,109 +19,87 @@ package clusters
 import (
 	"context"
 	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/instaclustr/operator/apis/clusters/v1beta1"
+	"github.com/instaclustr/operator/controllers/tests"
 	openapi "github.com/instaclustr/operator/pkg/instaclustr/mock/server/go"
-	"github.com/instaclustr/operator/pkg/models"
 )
 
 const newRedisNodeSize = "RDS-DEV-t4g.medium-80"
 
 var _ = Describe("Redis Controller", func() {
-	var (
-		redisResource v1beta1.Redis
-		redisYAML     v1beta1.Redis
-		k             = "redis"
-		ns            = "default"
-		redisNS       = types.NamespacedName{Name: k, Namespace: ns}
-		timeout       = time.Second * 40
-		interval      = time.Second * 2
-	)
+	redis := v1beta1.Redis{}
+	redisManifest := v1beta1.Redis{}
 
 	yfile, err := os.ReadFile("datatest/redis_v1beta1.yaml")
 	Expect(err).NotTo(HaveOccurred())
 
-	err = yaml.Unmarshal(yfile, &redisYAML)
+	err = yaml.Unmarshal(yfile, &redisManifest)
 	Expect(err).NotTo(HaveOccurred())
 
-	redisObjMeta := metav1.ObjectMeta{
-		Name:      k,
-		Namespace: ns,
-		Annotations: map[string]string{
-			models.ResourceStateAnnotation: models.CreatingEvent,
-		},
-	}
-
-	redisYAML.ObjectMeta = redisObjMeta
+	redisNamespacedName := types.NamespacedName{Name: redisManifest.ObjectMeta.Name, Namespace: defaultNS}
 
 	ctx := context.Background()
 
 	When("apply a redis manifest", func() {
 		It("should create a redis resources", func() {
-			Expect(k8sClient.Create(ctx, &redisYAML)).Should(Succeed())
-			By("sending redis specification to the Instaclustr API and get ID of created cluster.")
+			Expect(k8sClient.Create(ctx, &redisManifest)).Should(Succeed())
+			done := tests.NewChannelWithTimeout(timeout)
 
+			By("sending redis specification to the Instaclustr API and get ID of created cluster.")
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, redisNS, &redisResource); err != nil {
+				if err := k8sClient.Get(ctx, redisNamespacedName, &redis); err != nil {
 					return false
 				}
 
-				return redisResource.Status.ID == openapi.CreatedID
+				return redis.Status.ID == openapi.CreatedID
 			}).Should(BeTrue())
+
+			<-done
 		})
 	})
 
 	When("changing a node size", func() {
 		It("should update a redis resources", func() {
-			Expect(k8sClient.Get(ctx, redisNS, &redisResource)).Should(Succeed())
-			patch := redisResource.NewPatch()
+			Expect(k8sClient.Get(ctx, redisNamespacedName, &redis)).Should(Succeed())
 
-			redisResource.Spec.DataCentres[0].NodeSize = newRedisNodeSize
-
-			redisResource.Annotations = map[string]string{models.ResourceStateAnnotation: models.UpdatingEvent}
-			Expect(k8sClient.Patch(ctx, &redisResource, patch)).Should(Succeed())
-
+			patch := redis.NewPatch()
+			redis.Spec.DataCentres[0].NodeSize = newRedisNodeSize
+			Expect(k8sClient.Patch(ctx, &redis, patch)).Should(Succeed())
 			By("sending a resize request to the Instaclustr API. And when the resize is completed, " +
 				"the status job get new data from the InstAPI and update it in k8s redis resource")
-
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, redisNS, &redisResource); err != nil {
+				if err := k8sClient.Get(ctx, redisNamespacedName, &redis); err != nil {
 					return false
 				}
 
-				if len(redisResource.Status.DataCentres) == 0 || len(redisResource.Status.DataCentres[0].Nodes) == 0 {
+				if len(redis.Status.DataCentres) == 0 || len(redis.Status.DataCentres[0].Nodes) == 0 {
 					return false
 				}
 
-				return redisResource.Status.DataCentres[0].Nodes[0].Size == newRedisNodeSize
+				return redis.Status.DataCentres[0].Nodes[0].Size == newRedisNodeSize
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
 
 	When("delete the redis resource", func() {
 		It("should send delete request to the Instaclustr API", func() {
-			Expect(k8sClient.Get(ctx, redisNS, &redisResource)).Should(Succeed())
-
-			redisResource.Annotations = map[string]string{models.ResourceStateAnnotation: models.DeletingEvent}
-
-			Expect(k8sClient.Delete(ctx, &redisResource)).Should(Succeed())
-
+			Expect(k8sClient.Get(ctx, redisNamespacedName, &redis)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &redis)).Should(Succeed())
 			By("sending delete request to Instaclustr API")
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, redisNS, &redisResource)
+				err := k8sClient.Get(ctx, redisNamespacedName, &redis)
 				if err != nil && !k8serrors.IsNotFound(err) {
 					return false
 				}
 
-				return true
+				return k8serrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/controllers/clusters/suite_test.go
+++ b/controllers/clusters/suite_test.go
@@ -48,6 +48,11 @@ var (
 	testEnv   *envtest.Environment
 	ctx       context.Context
 	cancel    context.CancelFunc
+
+	defaultNS = "default"
+
+	timeout  = time.Millisecond * 1000
+	interval = time.Millisecond * 10
 )
 
 func TestAPIs(t *testing.T) {
@@ -93,9 +98,11 @@ var _ = BeforeSuite(func() {
 
 	eRecorder := k8sManager.GetEventRecorderFor("instaclustr-operator-tests")
 
-	scheduler.ClusterStatusInterval = 1 * time.Second
-	scheduler.ClusterBackupsInterval = 30 * time.Second
-	models.ReconcileRequeue = reconcile.Result{RequeueAfter: time.Second * 3}
+	scheduler.ClusterStatusInterval = time.Millisecond * 15
+	scheduler.ClusterBackupsInterval = time.Second * 30
+	scheduler.UserCreationInterval = interval
+
+	models.ReconcileRequeue = reconcile.Result{RequeueAfter: time.Millisecond * 5}
 
 	err = (&KafkaReconciler{
 		Client:        k8sManager.GetClient(),

--- a/controllers/kafkamanagement/datatest/kafkaacl_v1beta1.yaml
+++ b/controllers/kafkamanagement/datatest/kafkaacl_v1beta1.yaml
@@ -2,6 +2,9 @@ apiVersion: kafkamanagement.instaclustr.com/v1beta1
 kind: KafkaACL
 metadata:
   name: kafkaacl-sample
+  namespace: default
+  annotations:
+    defaulter: webhook
 spec:
   acls:
       - host: "*"

--- a/controllers/kafkamanagement/datatest/mirror_v1beta1.yaml
+++ b/controllers/kafkamanagement/datatest/mirror_v1beta1.yaml
@@ -2,6 +2,9 @@ apiVersion: kafkamanagement.instaclustr.com/v1beta1
 kind: Mirror
 metadata:
   name: mirror-sample
+  namespace: default
+  annotations:
+    defaulter: webhook
 spec:
   kafkaConnectClusterId: "897da890-a212-4771-ac13-b08d85e32ad6"
   maxTasks: 3

--- a/controllers/kafkamanagement/datatest/topic_v1beta1.yaml
+++ b/controllers/kafkamanagement/datatest/topic_v1beta1.yaml
@@ -2,6 +2,9 @@ apiVersion: kafkamanagement.instaclustr.com/v1beta1
 kind: Topic
 metadata:
   name: topic-sample
+  namespace: default
+  annotations:
+    defaulter: webhook
 spec:
   partitions: 3
   replicationFactor: 3

--- a/controllers/kafkamanagement/mirror_controller_test.go
+++ b/controllers/kafkamanagement/mirror_controller_test.go
@@ -19,85 +19,67 @@ package kafkamanagement
 import (
 	"context"
 	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/instaclustr/operator/apis/kafkamanagement/v1beta1"
+	"github.com/instaclustr/operator/controllers/tests"
 	openapi "github.com/instaclustr/operator/pkg/instaclustr/mock/server/go"
-	"github.com/instaclustr/operator/pkg/models"
 )
 
 var newMirrorLatency int32 = 3000
 
 var _ = Describe("Kafka Mirror Controller", func() {
-	var (
-		mirrorResource v1beta1.Mirror
-		mirrorYAML     v1beta1.Mirror
-		m              = "mirror"
-		ns             = "default"
-		mirrorNS       = types.NamespacedName{Name: m, Namespace: ns}
-		timeout        = time.Second * 40
-		interval       = time.Second * 2
-	)
+	mirror := v1beta1.Mirror{}
+	mirrorManifest := v1beta1.Mirror{}
 
 	yfile, err := os.ReadFile("datatest/mirror_v1beta1.yaml")
 	Expect(err).NotTo(HaveOccurred())
 
-	err = yaml.Unmarshal(yfile, &mirrorYAML)
+	err = yaml.Unmarshal(yfile, &mirrorManifest)
 	Expect(err).NotTo(HaveOccurred())
 
-	mirrorObjMeta := metav1.ObjectMeta{
-		Name:      m,
-		Namespace: ns,
-		Annotations: map[string]string{
-			models.ResourceStateAnnotation: models.CreatingEvent,
-		},
-	}
-
-	mirrorYAML.ObjectMeta = mirrorObjMeta
+	mirrorNamespacedName := types.NamespacedName{Name: mirrorManifest.ObjectMeta.Name, Namespace: defaultNS}
 
 	ctx := context.Background()
 
 	When("apply a Mirror manifest", func() {
 		It("should create a Mirror resources", func() {
-			Expect(k8sClient.Create(ctx, &mirrorYAML)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, &mirrorManifest)).Should(Succeed())
 			By("sending a Mirror specification to the Instaclustr API and get an ID of created resource.")
-
+			done := tests.NewChannelWithTimeout(timeout)
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, mirrorNS, &mirrorResource); err != nil {
+				if err := k8sClient.Get(ctx, mirrorNamespacedName, &mirror); err != nil {
 					return false
 				}
 
-				return mirrorResource.Status.ID != openapi.CreatedID
+				return mirror.Status.ID == openapi.CreatedID
 			}).Should(BeTrue())
+
+			<-done
 		})
 	})
 
 	When("changing a Mirror latency", func() {
 		It("should update the Mirror resources", func() {
-			Expect(k8sClient.Get(ctx, mirrorNS, &mirrorResource)).Should(Succeed())
-			patch := mirrorResource.NewPatch()
+			Expect(k8sClient.Get(ctx, mirrorNamespacedName, &mirror)).Should(Succeed())
 
-			mirrorResource.Spec.TargetLatency = newMirrorLatency
-			mirrorResource.Annotations = map[string]string{models.ResourceStateAnnotation: models.UpdatingEvent}
-
-			Expect(k8sClient.Patch(ctx, &mirrorResource, patch)).Should(Succeed())
+			patch := mirror.NewPatch()
+			mirror.Spec.TargetLatency = newMirrorLatency
+			Expect(k8sClient.Patch(ctx, &mirror, patch)).Should(Succeed())
 
 			By("sending a new Mirror configs request to the Instaclustr API, it" +
 				"gets a new data from the InstAPI and update it in k8s Mirror resource")
-
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, mirrorNS, &mirrorResource); err != nil {
+				if err := k8sClient.Get(ctx, mirrorNamespacedName, &mirror); err != nil {
 					return false
 				}
 
-				if mirrorResource.Status.TargetLatency != newMirrorLatency {
+				if mirror.Status.TargetLatency != newMirrorLatency {
 					return false
 				}
 
@@ -108,19 +90,16 @@ var _ = Describe("Kafka Mirror Controller", func() {
 
 	When("delete the Kafka resource", func() {
 		It("should send delete request to the Instaclustr API", func() {
-			Expect(k8sClient.Get(ctx, mirrorNS, &mirrorResource)).Should(Succeed())
-
-			mirrorResource.Annotations = map[string]string{models.ResourceStateAnnotation: models.DeletingEvent}
-			Expect(k8sClient.Delete(ctx, &mirrorResource)).Should(Succeed())
-
+			Expect(k8sClient.Get(ctx, mirrorNamespacedName, &mirror)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &mirror)).Should(Succeed())
 			By("sending delete request to Instaclustr API")
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, mirrorNS, &mirrorResource)
+				err := k8sClient.Get(ctx, mirrorNamespacedName, &mirror)
 				if err != nil && !k8serrors.IsNotFound(err) {
 					return false
 				}
 
-				return true
+				return k8serrors.IsNotFound(err)
 			}).Should(BeTrue())
 		})
 	})

--- a/controllers/kafkamanagement/suite_test.go
+++ b/controllers/kafkamanagement/suite_test.go
@@ -46,6 +46,11 @@ var (
 	testEnv   *envtest.Environment
 	ctx       context.Context
 	cancel    context.CancelFunc
+
+	defaultNS = "default"
+
+	timeout  = time.Millisecond * 500
+	interval = time.Millisecond * 5
 )
 
 func TestAPIs(t *testing.T) {
@@ -86,8 +91,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	scheduler.ClusterStatusInterval = 1 * time.Second
-	models.ReconcileRequeue = reconcile.Result{RequeueAfter: time.Second * 2}
+	scheduler.ClusterStatusInterval = time.Millisecond * 10
+	models.ReconcileRequeue = reconcile.Result{RequeueAfter: time.Millisecond * 3}
 
 	eRecorder := k8sManager.GetEventRecorderFor("instaclustr-operator-tests")
 

--- a/controllers/tests/helpers.go
+++ b/controllers/tests/helpers.go
@@ -1,0 +1,14 @@
+package tests
+
+import "time"
+
+// NewChannelWithTimeout creates a new channel that will be closed after a timeout.
+// This function is useful for synchronizing the execution of asynchronous assertion functions, such as Eventually().
+func NewChannelWithTimeout(timeout time.Duration) chan struct{} {
+	done := make(chan struct{}, 1)
+	_ = time.AfterFunc(timeout, func() {
+		close(done)
+	})
+
+	return done
+}


### PR DESCRIPTION
- Fixed a bug that caused a job to fail. I came to the conclusion that this is often found in scenarios related to simultaneous access to resources (async operation i.e. `Eventually()` from GinkGo ).
- Developed a test solution using Go channels for sequential testing (see `NewChannelWithTimeout()`).
- Decreased the test execution timeout from 60 seconds to 1 sec. :rocket:  :sunglasses: 
- Improved code readability.
- Made minor enhancements to resource controllers identified during test development.