### PR TITLE
AWS VPC Peering and Security Group Firewall rule cluster resources enhancement

### DIFF
--- a/pkg/instaclustr/client.go
+++ b/pkg/instaclustr/client.go
@@ -2265,3 +2265,33 @@ func (c *Client) GetResizeOperationsByClusterDataCentreID(cdcID string) ([]*v1be
 
 	return resize.Operations, nil
 }
+
+func (c *Client) GetAWSVPCPeering(peerID string) (*models.AWSVPCPeering, error) {
+	url := c.serverHostname + AWSPeeringEndpoint + peerID
+	resp, err := c.DoRequest(url, http.MethodGet, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, NotFound
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code: %d, message: %s", resp.StatusCode, b)
+	}
+
+	var vpcPeering models.AWSVPCPeering
+	err = json.Unmarshal(b, &vpcPeering)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vpcPeering, nil
+}

--- a/pkg/instaclustr/interfaces.go
+++ b/pkg/instaclustr/interfaces.go
@@ -34,6 +34,7 @@ type API interface {
 	UpdateCluster(id, clusterEndpoint string, instaDCs any) error
 	DeleteCluster(id, clusterEndpoint string) error
 	GetPeeringStatus(peerID, peeringEndpoint string) (*clusterresourcesv1beta1.PeeringStatus, error)
+	GetAWSVPCPeering(peerID string) (*models.AWSVPCPeering, error)
 	UpdatePeering(peerID, peeringEndpoint string, peerSpec any) error
 	DeletePeering(peerID, peeringEndpoint string) error
 	CreatePeering(url string, peeringSpec any) (*clusterresourcesv1beta1.PeeringStatus, error)

--- a/pkg/instaclustr/mock/client.go
+++ b/pkg/instaclustr/mock/client.go
@@ -367,3 +367,7 @@ func (c *mockClient) GetRedisUser(id string) (*models.RedisUser, error) {
 func (c *mockClient) GetResizeOperationsByClusterDataCentreID(cdcID string) ([]*clustersv1beta1.ResizeOperation, error) {
 	panic("GetResizeOperationsByClusterDataCentreID: is not implemented")
 }
+
+func (c *mockClient) GetAWSVPCPeering(peerID string) (*models.AWSVPCPeering, error) {
+	panic("GetAWSVPCPeering: is not implemented")
+}

--- a/pkg/models/apiv2.go
+++ b/pkg/models/apiv2.go
@@ -192,3 +192,14 @@ func (cb *ClusterBackup) GetBackupEvents(clusterKind string) map[int]*BackupEven
 
 	return instBackupEvents
 }
+
+type AWSVPCPeering struct {
+	ID               string   `json:"id"`
+	CDCID            string   `json:"cdcId"`
+	DataCentreVPCID  string   `json:"dataCentreVpcId"`
+	PeerAWSAccountID string   `json:"peerAwsAccountId"`
+	PeerRegion       string   `json:"peerRegion"`
+	PeerSubnets      []string `json:"peerSubnets"`
+	PeerVpcID        string   `json:"peerVpcId"`
+	StatusCode       string   `json:"statusCode"`
+}


### PR DESCRIPTION
Done:
- added handling of external changes for AWS VPC Peering cluster resources
- added deleting AWS VPC Peering resource if it doesn't exist on Instaclustr
- added deleting AWS Security Group Firewall Rule resource if it doesn't exist on Instaclustr
- fixed a bug in the AWS Security Group Firewall Rule status checker when it deletes itself