### PR TITLE
[WIP] ReconcileRequeue limitation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,13 @@ PHONY: stop-server-stub
 stop-server-stub: ## Stop an Instaclustr server-stub from your host.
 	docker stop instaclustr-server-stub
 
+.PHONY dev-build:
+dev-build: docker-build kind-load deploy ## builds docker-image, loads it to kind cluster and deploys operator
+
+.PHONY: kind-load
+kind-load: ## loads given image to kind cluster
+	kind load docker-image ${IMG}
+
 ##@ Deployment
 
 ifndef ignore-not-found

--- a/controllers/clusters/cassandra_controller.go
+++ b/controllers/clusters/cassandra_controller.go
@@ -40,6 +40,7 @@ import (
 	"github.com/instaclustr/operator/pkg/exposeservice"
 	"github.com/instaclustr/operator/pkg/instaclustr"
 	"github.com/instaclustr/operator/pkg/models"
+	"github.com/instaclustr/operator/pkg/reconcilerutils"
 	"github.com/instaclustr/operator/pkg/scheduler"
 )
 
@@ -1307,5 +1308,5 @@ func (r *CassandraReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				event.Object.GetAnnotations()[models.ResourceStateAnnotation] = models.GenericEvent
 				return true
 			},
-		})).Complete(r)
+		})).Complete(reconcilerutils.ReconcilerWithLimit(r))
 }

--- a/controllers/clusters/cassandra_controller.go
+++ b/controllers/clusters/cassandra_controller.go
@@ -1308,11 +1308,13 @@ func (r *CassandraReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				event.Object.GetAnnotations()[models.ResourceStateAnnotation] = models.GenericEvent
 				return true
 			},
-		})).Complete(reconcilerutils.ReconcilerWithLimit(r, reconcilerutils.ReconcilerWithLimitOptions{
-		EventRecorder: r.EventRecorder,
-		Client:        r.Client,
-		MaxRetries:    2,
-		For:           &v1beta1.Cassandra{},
-		Scheme:        r.Scheme,
-	}))
+		})).
+		Complete(reconcilerutils.NewReconciler(r.Scheme).
+			For(&v1beta1.Cassandra{}).
+			WithReconcileRequeueLimit(2).
+			WithEvents(&reconcilerutils.WithEventsOptions{
+				EventRecorder: r.EventRecorder,
+				Client:        r.Client,
+			}).
+			Complete(r))
 }

--- a/controllers/clusters/cassandra_controller.go
+++ b/controllers/clusters/cassandra_controller.go
@@ -1308,5 +1308,11 @@ func (r *CassandraReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				event.Object.GetAnnotations()[models.ResourceStateAnnotation] = models.GenericEvent
 				return true
 			},
-		})).Complete(reconcilerutils.ReconcilerWithLimit(r))
+		})).Complete(reconcilerutils.ReconcilerWithLimit(r, reconcilerutils.ReconcilerWithLimitOptions{
+		EventRecorder: r.EventRecorder,
+		Client:        r.Client,
+		MaxRetries:    2,
+		For:           &v1beta1.Cassandra{},
+		Scheme:        r.Scheme,
+	}))
 }

--- a/pkg/reconcilerutils/reconcile-requeue-limiter.go
+++ b/pkg/reconcilerutils/reconcile-requeue-limiter.go
@@ -1,0 +1,58 @@
+package reconcilerutils
+
+import (
+	"context"
+	"github.com/instaclustr/operator/pkg/models"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const MaxReconcileRequeueRetries = 5
+
+func ReconcilerWithLimit(r reconcile.Reconciler) reconcile.Func {
+	limiter := &ReconcileRequeueLimiter{
+		maxRetries: MaxReconcileRequeueRetries,
+		m:          make(map[types.NamespacedName]int),
+	}
+
+	return func(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+		if !limiter.RequeueAllowed(req.NamespacedName) {
+			l := log.FromContext(ctx)
+			l.Info("Amount of reconcile requeue retries reached its maximum for the resource",
+				"req", req.NamespacedName,
+			)
+
+			limiter.Reset(req.NamespacedName)
+
+			return models.ExitReconcile, nil
+		}
+
+		result, err := r.Reconcile(ctx, req)
+		if err != nil || result == models.ReconcileRequeue {
+			limiter.Requeue(req.NamespacedName)
+			return result, err
+		}
+
+		limiter.Reset(req.NamespacedName)
+
+		return result, nil
+	}
+}
+
+type ReconcileRequeueLimiter struct {
+	maxRetries int
+	m          map[types.NamespacedName]int
+}
+
+func (r *ReconcileRequeueLimiter) Requeue(key types.NamespacedName) {
+	r.m[key]++
+}
+
+func (r *ReconcileRequeueLimiter) RequeueAllowed(key types.NamespacedName) bool {
+	return r.m[key] < r.maxRetries
+}
+
+func (r *ReconcileRequeueLimiter) Reset(key types.NamespacedName) {
+	delete(r.m, key)
+}

--- a/pkg/reconcilerutils/reconcile-requeue-limiter.go
+++ b/pkg/reconcilerutils/reconcile-requeue-limiter.go
@@ -2,28 +2,87 @@ package reconcilerutils
 
 import (
 	"context"
-	"github.com/instaclustr/operator/pkg/models"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/instaclustr/operator/pkg/models"
 )
 
 const MaxReconcileRequeueRetries = 5
 
-func ReconcilerWithLimit(r reconcile.Reconciler) reconcile.Func {
+type ReconcilerWithLimitOptions struct {
+	EventRecorder record.EventRecorder
+	Client        client.Client
+	MaxRetries    int
+	For           client.Object
+	Scheme        *runtime.Scheme
+}
+
+func ReconcilerWithLimit(r reconcile.Reconciler, opts ...ReconcilerWithLimitOptions) reconcile.Func {
 	limiter := &ReconcileRequeueLimiter{
-		maxRetries: MaxReconcileRequeueRetries,
-		m:          make(map[types.NamespacedName]int),
+		m: make(map[types.NamespacedName]int),
+	}
+
+	var (
+		eventRecorder record.EventRecorder
+		client        client.Client
+		withEvents    bool
+		gvk           schema.GroupVersionKind
+	)
+
+	if opts != nil {
+		opt := opts[0]
+		if opt.EventRecorder != nil && opt.Client != nil && opt.For != nil && opt.Scheme != nil {
+			withEvents = true
+			eventRecorder = opt.EventRecorder
+			client = opt.Client
+
+			var err error
+			gvk, err = apiutil.GVKForObject(opt.For, opt.Scheme)
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		if opt.MaxRetries < 1 {
+			limiter.maxRetries = MaxReconcileRequeueRetries
+		} else {
+			limiter.maxRetries = opt.MaxRetries
+		}
 	}
 
 	return func(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 		if !limiter.RequeueAllowed(req.NamespacedName) {
-			l := log.FromContext(ctx)
+			limiter.Reset(req.NamespacedName)
+
+			l := log.FromContext(ctx).WithValues("component", "reconcile-requeue-limiter")
+
 			l.Info("Amount of reconcile requeue retries reached its maximum for the resource",
 				"req", req.NamespacedName,
 			)
 
-			limiter.Reset(req.NamespacedName)
+			if withEvents {
+				obj := &unstructured.Unstructured{}
+				obj.SetGroupVersionKind(gvk)
+
+				err := client.Get(ctx, req.NamespacedName, obj)
+				if err != nil {
+					l.Error(err, "Failed to get the resource", "req", req.NamespacedName)
+					return models.ExitReconcile, nil
+				}
+
+				eventRecorder.Eventf(obj, models.Warning, models.GenericEvent,
+					"Amount of reconcile requeue retries reached its maximum: %v", limiter.maxRetries,
+				)
+			}
 
 			return models.ExitReconcile, nil
 		}


### PR DESCRIPTION
### Reconcile Requeue limitation #559

Implemented ReconcileRequeue limiter which limits the amount of reconciles for each resource controlled by its `namespacedName`.

The limiter was implemented as a wrapper on the `reconcile.Reconciler` interface. 

### Usage

The limiter can be used in the `SetupWithManager` func as shown in the Cassandra example.

If the `reconcile.result == models.ReconcileRequeue` the limiter increments amount of reconciles for the resource.

If the result is `models.ExitReconcile` the limiter resets the counter.

Also if the amount of ReconcileRequeues reaches the `MaxReconcileRequeueRetries` limiter, it finishes the current reconcile with the `models.ExtiReconcile` result and resets the counter for the resource.

Also, I added a useful script `dev-build` to Makefile which avoids pushing docker-images to the DockerHub by loading them to Kind directly. 