### PR TITLE
External Deletion for clusters

### DIFF
--- a/controllers/clusters/cassandra_controller_test.go
+++ b/controllers/clusters/cassandra_controller_test.go
@@ -28,7 +28,9 @@ import (
 
 	"github.com/instaclustr/operator/apis/clusters/v1beta1"
 	"github.com/instaclustr/operator/controllers/tests"
+	"github.com/instaclustr/operator/pkg/instaclustr"
 	openapi "github.com/instaclustr/operator/pkg/instaclustr/mock/server/go"
+	"github.com/instaclustr/operator/pkg/models"
 )
 
 const newCassandraNodeSize = "CAS-DEV-t4g.small-30"
@@ -106,4 +108,51 @@ var _ = Describe("Cassandra Controller", func() {
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
+
+	When("Deleting the Cassandra resource by avoiding operator", func() {
+		It("should try to get the cluster details and receive StatusNotFound", func() {
+			cassandraManifest2 := cassandraManifest.DeepCopy()
+			cassandraManifest2.Name += "-test-external-delete"
+			cassandraManifest2.ResourceVersion = ""
+
+			cassandra2 := v1beta1.Cassandra{}
+			cassandra2NamespacedName := types.NamespacedName{
+				Namespace: cassandraManifest2.Namespace,
+				Name:      cassandraManifest2.Name,
+			}
+
+			Expect(k8sClient.Create(ctx, cassandraManifest2)).Should(Succeed())
+
+			doneCh := tests.NewChannelWithTimeout(timeout)
+
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, cassandra2NamespacedName, &cassandra2); err != nil {
+					return false
+				}
+
+				if cassandra2.Status.State != models.RunningStatus {
+					return false
+				}
+
+				doneCh <- struct{}{}
+
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			<-doneCh
+
+			By("using all possible ways other than k8s to delete a resource, the k8s operator scheduler should notice the changes and set the status of the deleted resource accordingly")
+			Expect(instaClient.DeleteCluster(cassandra2.Status.ID, instaclustr.CassandraEndpoint)).Should(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, cassandra2NamespacedName, &cassandra2)
+				if err != nil {
+					return false
+				}
+
+				return cassandra2.Status.State == models.DeletedStatus
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
 })

--- a/controllers/clusters/helpers.go
+++ b/controllers/clusters/helpers.go
@@ -135,18 +135,6 @@ func isDataCentreNodesEqual(a, b []*v1beta1.Node) bool {
 	return true
 }
 
-func isClusterActive(clusterID string, activeClusters []*models.ActiveClusters) bool {
-	for _, activeCluster := range activeClusters {
-		for _, cluster := range activeCluster.Clusters {
-			if cluster.ID == clusterID {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
 func getSortedAppVersions(versions []*models.AppVersions, appType string) []*version.Version {
 	for _, apps := range versions {
 		if apps.Application == appType {

--- a/controllers/clusters/kafkaconnect_controller_test.go
+++ b/controllers/clusters/kafkaconnect_controller_test.go
@@ -18,6 +18,7 @@ package clusters
 
 import (
 	"context"
+	openapi "github.com/instaclustr/operator/pkg/instaclustr/mock/server/go"
 	"os"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,7 +29,8 @@ import (
 
 	"github.com/instaclustr/operator/apis/clusters/v1beta1"
 	"github.com/instaclustr/operator/controllers/tests"
-	openapi "github.com/instaclustr/operator/pkg/instaclustr/mock/server/go"
+	"github.com/instaclustr/operator/pkg/instaclustr"
+	"github.com/instaclustr/operator/pkg/models"
 )
 
 const newKafkaConnectNodeNumbers = 6
@@ -47,6 +49,7 @@ var _ = Describe("Kafka Connect Controller", func() {
 
 	ctx := context.Background()
 
+	clusterID := kafkaConnectManifest.Spec.Name + openapi.CreatedID
 	When("apply a Kafka Connect manifest", func() {
 		It("should create a Kafka Connect resources", func() {
 			Expect(k8sClient.Create(ctx, &kafkaConnectManifest)).Should(Succeed())
@@ -58,10 +61,26 @@ var _ = Describe("Kafka Connect Controller", func() {
 					return false
 				}
 
-				return kafkaConnect.Status.ID == openapi.CreatedID
+				return kafkaConnect.Status.ID == clusterID
 			}).Should(BeTrue())
 
 			<-done
+
+			By("creating secret with the default user credentials")
+			secret := kafkaConnect.NewDefaultUserSecret("", "")
+			secretNamespacedName := types.NamespacedName{
+				Namespace: secret.Namespace,
+				Name:      secret.Name,
+			}
+
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, secretNamespacedName, secret); err != nil {
+					return false
+				}
+
+				return string(secret.Data[models.Username]) == kafkaConnect.Status.ID+"_username" &&
+					string(secret.Data[models.Password]) == kafkaConnect.Status.ID+"_password"
+			}).Should(BeTrue())
 		})
 	})
 
@@ -101,6 +120,52 @@ var _ = Describe("Kafka Connect Controller", func() {
 				}
 
 				return k8serrors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	When("Deleting the Kafka Connect resource by avoiding operator", func() {
+		It("should try to get the cluster details and receive StatusNotFound", func() {
+			kafkaConnectManifest2 := kafkaConnectManifest.DeepCopy()
+			kafkaConnectManifest2.Name += "-test-external-delete"
+			kafkaConnectManifest2.ResourceVersion = ""
+
+			kafkaConnect2 := v1beta1.KafkaConnect{}
+			kafkaConnect2NamespacedName := types.NamespacedName{
+				Namespace: kafkaConnectManifest2.Namespace,
+				Name:      kafkaConnectManifest2.Name,
+			}
+
+			Expect(k8sClient.Create(ctx, kafkaConnectManifest2)).Should(Succeed())
+
+			doneCh := tests.NewChannelWithTimeout(timeout)
+
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, kafkaConnect2NamespacedName, &kafkaConnect2); err != nil {
+					return false
+				}
+
+				if kafkaConnect2.Status.State != models.RunningStatus {
+					return false
+				}
+
+				doneCh <- struct{}{}
+
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			<-doneCh
+
+			By("using all possible ways other than k8s to delete a resource, the k8s operator scheduler should notice the changes and set the status of the deleted resource accordingly")
+			Expect(instaClient.DeleteCluster(kafkaConnect2.Status.ID, instaclustr.KafkaConnectEndpoint)).Should(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, kafkaConnect2NamespacedName, &kafkaConnect2)
+				if err != nil {
+					return false
+				}
+
+				return kafkaConnect2.Status.State == models.DeletedStatus
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/controllers/clusters/suite_test.go
+++ b/controllers/clusters/suite_test.go
@@ -53,6 +53,8 @@ var (
 
 	timeout  = time.Millisecond * 1000
 	interval = time.Millisecond * 10
+
+	instaClient = instaclustr.NewClient("test", "test", "http://localhost:8082", time.Second*10)
 )
 
 func TestAPIs(t *testing.T) {
@@ -76,8 +78,6 @@ var _ = BeforeSuite(func() {
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
-
-	instaClient := instaclustr.NewClient("test", "test", "http://localhost:8082", time.Second*10)
 
 	err = v1beta1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/instaclustr/errors.go
+++ b/pkg/instaclustr/errors.go
@@ -25,3 +25,4 @@ var (
 )
 
 const MsgDeleteUser = "If you want to delete the user, remove it from the clusters specifications first"
+const MsgInstaclustrResourceNotFound = "The resource is not found on Instaclustr, changing its state to deleted"

--- a/pkg/instaclustr/mock/server/go/api.go
+++ b/pkg/instaclustr/mock/server/go/api.go
@@ -548,6 +548,7 @@ type AzureVnetPeerV2APIServicer interface {
 type BundleUserAPIServicer interface {
 	CreateUser(context.Context, string, string, BundleUserCreateRequest) (ImplResponse, error)
 	DeleteUser(context.Context, string, string, BundleUserDeleteRequest) (ImplResponse, error)
+	GetDefaultCreds(ctx context.Context, clusterID string) (ImplResponse, error)
 }
 
 // CadenceProvisioningV2APIServicer defines the api actions for the CadenceProvisioningV2API service

--- a/pkg/instaclustr/mock/server/go/api_apache_cassandra_provisioning_v2_service.go
+++ b/pkg/instaclustr/mock/server/go/api_apache_cassandra_provisioning_v2_service.go
@@ -19,12 +19,12 @@ import (
 // This service should implement the business logic for every endpoint for the ApacheCassandraProvisioningV2API API.
 // Include any external packages or services that will be required by this service.
 type ApacheCassandraProvisioningV2APIService struct {
-	MockCassandraClusters []*CassandraClusterV2
+	clusters map[string]*CassandraClusterV2
 }
 
 // NewApacheCassandraProvisioningV2APIService creates a default api service
 func NewApacheCassandraProvisioningV2APIService() ApacheCassandraProvisioningV2APIServicer {
-	return &ApacheCassandraProvisioningV2APIService{}
+	return &ApacheCassandraProvisioningV2APIService{clusters: map[string]*CassandraClusterV2{}}
 }
 
 // ClusterManagementV2DataSourcesApplicationsCassandraClustersV2ClusterIdListBackupsV2Get - List recent cluster backup events.
@@ -64,12 +64,12 @@ func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2OperationsA
 func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsCassandraClustersV2ClusterIdDelete(ctx context.Context, clusterId string) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsCassandraClustersV2ClusterIdDelete with the required logic for this service method.
 	// Add api_apache_cassandra_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
-	c := s.getCluster(clusterId)
-	if c == nil {
+	_, exists := s.clusters[clusterId]
+	if !exists {
 		return Response(http.StatusNotFound, nil), nil
 	}
 
-	c = nil
+	delete(s.clusters, clusterId)
 
 	return Response(http.StatusNoContent, nil), nil
 }
@@ -79,8 +79,8 @@ func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2ResourcesAp
 	// TODO - update ClusterManagementV2ResourcesApplicationsCassandraClustersV2ClusterIdGet with the required logic for this service method.
 	// Add api_apache_cassandra_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	c := s.getCluster(clusterId)
-	if c == nil {
+	c, exists := s.clusters[clusterId]
+	if !exists {
 		return Response(http.StatusNotFound, nil), nil
 	}
 
@@ -94,9 +94,9 @@ func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2ResourcesAp
 	// TODO - update ClusterManagementV2ResourcesApplicationsCassandraClustersV2ClusterIdPut with the required logic for this service method.
 	// Add api_apache_cassandra_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	c := s.getCluster(clusterId)
-	if c == nil {
-		return Response(404, nil), nil
+	c, exists := s.clusters[clusterId]
+	if !exists {
+		return Response(http.StatusNotFound, nil), nil
 	}
 
 	newNode := []NodeDetailsV2{{
@@ -121,17 +121,7 @@ func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2ResourcesAp
 	newCassandra.Id = cassandraClusterV2.Name + CreatedID
 	newCassandra.DataCentres[0].Nodes = []NodeDetailsV2{{NodeSize: cassandraClusterV2.DataCentres[0].NodeSize}}
 
-	s.MockCassandraClusters = append(s.MockCassandraClusters, newCassandra)
+	s.clusters[newCassandra.Id] = newCassandra
 
 	return Response(http.StatusAccepted, newCassandra), nil
-}
-
-func (s *ApacheCassandraProvisioningV2APIService) getCluster(clusterID string) *CassandraClusterV2 {
-	for _, c := range s.MockCassandraClusters {
-		if c.Id == clusterID {
-			return c
-		}
-	}
-
-	return nil
 }

--- a/pkg/instaclustr/mock/server/go/api_apache_kafka_connect_provisioning_v2_service.go
+++ b/pkg/instaclustr/mock/server/go/api_apache_kafka_connect_provisioning_v2_service.go
@@ -19,12 +19,12 @@ import (
 // This service should implement the business logic for every endpoint for the ApacheKafkaConnectProvisioningV2API API.
 // Include any external packages or services that will be required by this service.
 type ApacheKafkaConnectProvisioningV2APIService struct {
-	MockKafkaConnectCluster *KafkaConnectClusterV2
+	clusters map[string]*KafkaConnectClusterV2
 }
 
 // NewApacheKafkaConnectProvisioningV2APIService creates a default api service
 func NewApacheKafkaConnectProvisioningV2APIService() ApacheKafkaConnectProvisioningV2APIServicer {
-	return &ApacheKafkaConnectProvisioningV2APIService{}
+	return &ApacheKafkaConnectProvisioningV2APIService{clusters: map[string]*KafkaConnectClusterV2{}}
 }
 
 // ClusterManagementV2OperationsApplicationsKafkaConnectClustersV2ClusterIdSyncCustomKafkaConnectorsV2Put - Update the custom connectors of a Kafka Connect cluster.
@@ -43,7 +43,7 @@ func (s *ApacheKafkaConnectProvisioningV2APIService) ClusterManagementV2Resource
 	// TODO - update ClusterManagementV2ResourcesApplicationsKafkaConnectClustersV2ClusterIdDelete with the required logic for this service method.
 	// Add api_apache_kafka_connect_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	s.MockKafkaConnectCluster = nil
+	delete(s.clusters, clusterId)
 	return Response(204, nil), nil
 }
 
@@ -52,13 +52,14 @@ func (s *ApacheKafkaConnectProvisioningV2APIService) ClusterManagementV2Resource
 	// TODO - update ClusterManagementV2ResourcesApplicationsKafkaConnectClustersV2ClusterIdGet with the required logic for this service method.
 	// Add api_apache_kafka_connect_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	if s.MockKafkaConnectCluster != nil {
-		s.MockKafkaConnectCluster.Status = RUNNING
-	} else {
+	cluster, exists := s.clusters[clusterId]
+	if !exists {
 		return Response(404, nil), nil
 	}
 
-	return Response(200, s.MockKafkaConnectCluster), nil
+	cluster.Status = RUNNING
+
+	return Response(200, cluster), nil
 }
 
 // ClusterManagementV2ResourcesApplicationsKafkaConnectClustersV2ClusterIdPut - Update a Kafka connect cluster
@@ -66,7 +67,12 @@ func (s *ApacheKafkaConnectProvisioningV2APIService) ClusterManagementV2Resource
 	// TODO - update ClusterManagementV2ResourcesApplicationsKafkaConnectClustersV2ClusterIdPut with the required logic for this service method.
 	// Add api_apache_kafka_connect_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	s.MockKafkaConnectCluster.DataCentres[0].NumberOfNodes = kafkaConnectClusterUpdateV2.DataCentres[0].NumberOfNodes
+	cluster, exists := s.clusters[clusterId]
+	if !exists {
+		return Response(404, nil), nil
+	}
+
+	cluster.DataCentres[0].NumberOfNodes = kafkaConnectClusterUpdateV2.DataCentres[0].NumberOfNodes
 
 	return Response(202, nil), nil
 
@@ -79,7 +85,8 @@ func (s *ApacheKafkaConnectProvisioningV2APIService) ClusterManagementV2Resource
 	// TODO - update ClusterManagementV2ResourcesApplicationsKafkaConnectClustersV2Post with the required logic for this service method.
 	// Add api_apache_kafka_connect_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	s.MockKafkaConnectCluster = &kafkaConnectClusterV2
-	s.MockKafkaConnectCluster.Id = CreatedID
-	return Response(202, s.MockKafkaConnectCluster), nil
+	kafkaConnectClusterV2.Id = kafkaConnectClusterV2.Name + CreatedID
+	s.clusters[kafkaConnectClusterV2.Id] = &kafkaConnectClusterV2
+
+	return Response(202, kafkaConnectClusterV2), nil
 }

--- a/pkg/instaclustr/mock/server/go/api_apache_kafka_provisioning_v2_service.go
+++ b/pkg/instaclustr/mock/server/go/api_apache_kafka_provisioning_v2_service.go
@@ -17,12 +17,12 @@ import (
 // This service should implement the business logic for every endpoint for the ApacheKafkaProvisioningV2API API.
 // Include any external packages or services that will be required by this service.
 type ApacheKafkaProvisioningV2APIService struct {
-	MockKafkaCluster *KafkaClusterV2
+	clusters map[string]*KafkaClusterV2
 }
 
 // NewApacheKafkaProvisioningV2APIService creates a default api service
 func NewApacheKafkaProvisioningV2APIService() ApacheKafkaProvisioningV2APIServicer {
-	return &ApacheKafkaProvisioningV2APIService{}
+	return &ApacheKafkaProvisioningV2APIService{clusters: map[string]*KafkaClusterV2{}}
 }
 
 // ClusterManagementV2ResourcesApplicationsKafkaClustersV2ClusterIdDelete - Delete cluster
@@ -30,7 +30,7 @@ func (s *ApacheKafkaProvisioningV2APIService) ClusterManagementV2ResourcesApplic
 	// TODO - update ClusterManagementV2ResourcesApplicationsKafkaClustersV2ClusterIdDelete with the required logic for this service method.
 	// Add api_apache_kafka_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	s.MockKafkaCluster = nil
+	delete(s.clusters, clusterId)
 	return Response(204, nil), nil
 }
 
@@ -39,19 +39,25 @@ func (s *ApacheKafkaProvisioningV2APIService) ClusterManagementV2ResourcesApplic
 	// TODO - update ClusterManagementV2ResourcesApplicationsKafkaClustersV2ClusterIdGet with the required logic for this service method.
 	// Add api_apache_kafka_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	if s.MockKafkaCluster != nil {
-		s.MockKafkaCluster.Status = RUNNING
-	} else {
+	cluster, exists := s.clusters[clusterId]
+	if !exists {
 		return Response(404, nil), nil
 	}
 
-	return Response(200, s.MockKafkaCluster), nil
+	cluster.Status = RUNNING
+
+	return Response(200, cluster), nil
 }
 
 // ClusterManagementV2ResourcesApplicationsKafkaClustersV2ClusterIdPut - Update Kafka Cluster Details
 func (s *ApacheKafkaProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsKafkaClustersV2ClusterIdPut(ctx context.Context, clusterId string, kafkaClusterUpdateV2 KafkaClusterUpdateV2) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsKafkaClustersV2ClusterIdPut with the required logic for this service method.
 	// Add api_apache_kafka_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	cluster, exists := s.clusters[clusterId]
+	if !exists {
+		return Response(404, nil), nil
+	}
 
 	newNode := []NodeDetailsV2{{
 		NodeRoles:     []NodeRolesV2{"KAFKA_BROKER", "KAFKA_ZOOKEEPER"},
@@ -60,7 +66,7 @@ func (s *ApacheKafkaProvisioningV2APIService) ClusterManagementV2ResourcesApplic
 		PublicAddress: "54.146.160.89",
 	}}
 
-	s.MockKafkaCluster.DataCentres[0].Nodes = newNode
+	cluster.DataCentres[0].Nodes = newNode
 
 	return Response(202, nil), nil
 
@@ -73,7 +79,8 @@ func (s *ApacheKafkaProvisioningV2APIService) ClusterManagementV2ResourcesApplic
 	// TODO - update ClusterManagementV2ResourcesApplicationsKafkaClustersV2Post with the required logic for this service method.
 	// Add api_apache_kafka_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	s.MockKafkaCluster = &kafkaClusterV2
-	s.MockKafkaCluster.Id = CreatedID
-	return Response(202, s.MockKafkaCluster), nil
+	kafkaClusterV2.Id = kafkaClusterV2.Name + CreatedID
+	s.clusters[kafkaClusterV2.Id] = &kafkaClusterV2
+
+	return Response(202, kafkaClusterV2), nil
 }

--- a/pkg/instaclustr/mock/server/go/api_bundle_user.go
+++ b/pkg/instaclustr/mock/server/go/api_bundle_user.go
@@ -60,6 +60,11 @@ func (c *BundleUserAPIController) Routes() Routes {
 			"/provisioning/v1/{clusterId}/{bundle}/users",
 			c.DeleteUser,
 		},
+		"GetDefaultCreds": Route{
+			strings.ToUpper("Get"),
+			"/provisioning/v1/{clusterId}",
+			c.GetDefaultCreds,
+		},
 	}
 }
 
@@ -120,5 +125,19 @@ func (c *BundleUserAPIController) DeleteUser(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// If no error, encode the body and the result code
+	EncodeJSONResponse(result.Body, &result.Code, w)
+}
+
+func (c *BundleUserAPIController) GetDefaultCreds(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+
+	clusterID := params["clusterId"]
+
+	result, err := c.service.GetDefaultCreds(r.Context(), clusterID)
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+
 	EncodeJSONResponse(result.Body, &result.Code, w)
 }

--- a/pkg/instaclustr/mock/server/go/api_bundle_user_service.go
+++ b/pkg/instaclustr/mock/server/go/api_bundle_user_service.go
@@ -11,6 +11,7 @@ package openapi
 
 import (
 	"context"
+	"net/http"
 )
 
 // BundleUserAPIService is a service that implements the logic for the BundleUserAPIServicer
@@ -68,4 +69,16 @@ func (s *BundleUserAPIService) DeleteUser(ctx context.Context, clusterId string,
 	// return Response(504, nil),nil
 
 	return Response(200, GenericResponse{}), nil
+}
+
+func (s *BundleUserAPIService) GetDefaultCreds(ctx context.Context, clusterID string) (ImplResponse, error) {
+	creds := &struct {
+		Username                string `json:"username"`
+		InstaclustrUserPassword string `json:"instaclustrUserPassword"`
+	}{
+		Username:                clusterID + "_username",
+		InstaclustrUserPassword: clusterID + "_password",
+	}
+
+	return Response(http.StatusAccepted, creds), nil
 }

--- a/pkg/instaclustr/mock/server/go/api_open_search_provisioning_v2_service.go
+++ b/pkg/instaclustr/mock/server/go/api_open_search_provisioning_v2_service.go
@@ -19,12 +19,12 @@ import (
 // This service should implement the business logic for every endpoint for the OpenSearchProvisioningV2API API.
 // Include any external packages or services that will be required by this service.
 type OpenSearchProvisioningV2APIService struct {
-	MockOpenSearchCluster []*OpenSearchClusterV2
+	clusters map[string]*OpenSearchClusterV2
 }
 
 // NewOpenSearchProvisioningV2APIService creates a default api service
 func NewOpenSearchProvisioningV2APIService() OpenSearchProvisioningV2APIServicer {
-	return &OpenSearchProvisioningV2APIService{}
+	return &OpenSearchProvisioningV2APIService{clusters: map[string]*OpenSearchClusterV2{}}
 }
 
 // ClusterManagementV2DataSourcesApplicationsOpensearchClustersV2ClusterIdListBackupsV2Get - List recent cluster backup events.
@@ -65,12 +65,13 @@ func (s *OpenSearchProvisioningV2APIService) ClusterManagementV2ResourcesApplica
 	// TODO - update ClusterManagementV2ResourcesApplicationsOpensearchClustersV2ClusterIdDelete with the required logic for this service method.
 	// Add api_open_search_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	o := s.getCluster(clusterId)
-	if o == nil {
+	_, exists := s.clusters[clusterId]
+	if !exists {
 		return Response(http.StatusNotFound, nil), nil
 	}
 
-	o = nil
+	delete(s.clusters, clusterId)
+
 	return Response(http.StatusNoContent, nil), nil
 }
 
@@ -79,8 +80,8 @@ func (s *OpenSearchProvisioningV2APIService) ClusterManagementV2ResourcesApplica
 	// TODO - update ClusterManagementV2ResourcesApplicationsOpensearchClustersV2ClusterIdGet with the required logic for this service method.
 	// Add api_open_search_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	o := s.getCluster(clusterId)
-	if o == nil {
+	o, exists := s.clusters[clusterId]
+	if !exists {
 		return Response(http.StatusNotFound, nil), nil
 	}
 
@@ -94,8 +95,8 @@ func (s *OpenSearchProvisioningV2APIService) ClusterManagementV2ResourcesApplica
 	// TODO - update ClusterManagementV2ResourcesApplicationsOpensearchClustersV2ClusterIdPut with the required logic for this service method.
 	// Add api_open_search_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	o := s.getCluster(clusterId)
-	if o == nil {
+	o, exists := s.clusters[clusterId]
+	if !exists {
 		return Response(http.StatusNotFound, nil), nil
 	}
 
@@ -119,17 +120,7 @@ func (s *OpenSearchProvisioningV2APIService) ClusterManagementV2ResourcesApplica
 	newOpenSearch = &openSearchClusterV2
 	newOpenSearch.Id = openSearchClusterV2.Name + CreatedID
 
-	s.MockOpenSearchCluster = append(s.MockOpenSearchCluster, newOpenSearch)
+	s.clusters[newOpenSearch.Id] = newOpenSearch
 
 	return Response(202, newOpenSearch), nil
-}
-
-func (s *OpenSearchProvisioningV2APIService) getCluster(clusterID string) *OpenSearchClusterV2 {
-	for _, o := range s.MockOpenSearchCluster {
-		if o.Id == clusterID {
-			return o
-		}
-	}
-
-	return nil
 }

--- a/pkg/models/apiv1.go
+++ b/pkg/models/apiv1.go
@@ -18,7 +18,6 @@ package models
 
 const (
 	RunningStatus = "RUNNING"
-	Disabled      = "DISABLED"
 )
 
 type ClusterProviderV1 struct {

--- a/pkg/models/apiv2.go
+++ b/pkg/models/apiv2.go
@@ -20,6 +20,8 @@ const (
 	NoOperation         = "NO_OPERATION"
 	OperationInProgress = "OPERATION_IN_PROGRESS"
 
+	DeletedStatus = "DELETED"
+
 	DefaultAccountName = "INSTACLUSTR"
 
 	AWSVPC  = "AWS_VPC"

--- a/pkg/models/operator.go
+++ b/pkg/models/operator.go
@@ -139,6 +139,7 @@ const (
 	DeletionStarted  = "DeletionStarted"
 	DeletionFailed   = "DeletionFailed"
 	Deleted          = "Deleted"
+	ExternalDeleted  = "ExternalDeleted"
 )
 
 const (


### PR DESCRIPTION
Implemented handling of the external deletion of resources. In the previous implementation if there was no resource on the Instaclustr we deleted it in k8s. Now it changes a resource state to `DELETED` without deleting it in k8s.