### PR TITLE
Handling external deletion of the resources in the clusterresources group

### DIFF
--- a/apis/clusterresources/v1beta1/awsencryptionkey_types.go
+++ b/apis/clusterresources/v1beta1/awsencryptionkey_types.go
@@ -34,6 +34,7 @@ type AWSEncryptionKeySpec struct {
 type AWSEncryptionKeyStatus struct {
 	ID    string `json:"id,omitempty"`
 	InUse bool   `json:"inUse,omitempty"`
+	State string `json:"state,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/apis/clusterresources/v1beta1/awsendpointserviceprincipal_types.go
+++ b/apis/clusterresources/v1beta1/awsendpointserviceprincipal_types.go
@@ -40,6 +40,9 @@ type AWSEndpointServicePrincipalStatus struct {
 
 	// The Instaclustr ID of the AWS endpoint service
 	EndPointServiceID string `json:"endPointServiceId,omitempty"`
+
+	// State describe current state of the resource
+	State string `json:"state,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -56,6 +59,10 @@ type AWSEndpointServicePrincipal struct {
 
 func (r *AWSEndpointServicePrincipal) NewPatch() client.Patch {
 	return client.MergeFrom(r.DeepCopy())
+}
+
+func (r *AWSEndpointServicePrincipal) GetJobID(job string) string {
+	return r.Namespace + "/" + r.Name + "/" + job
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/clusterresources.instaclustr.com_awsencryptionkeys.yaml
+++ b/config/crd/bases/clusterresources.instaclustr.com_awsencryptionkeys.yaml
@@ -52,6 +52,8 @@ spec:
                 type: string
               inUse:
                 type: boolean
+              state:
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/clusterresources.instaclustr.com_awsendpointserviceprincipals.yaml
+++ b/config/crd/bases/clusterresources.instaclustr.com_awsendpointserviceprincipals.yaml
@@ -60,6 +60,9 @@ spec:
               id:
                 description: The Instaclustr ID of the IAM Principal ARN
                 type: string
+              state:
+                description: State describe current state of the resource
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/clusterresources/helpers.go
+++ b/controllers/clusterresources/helpers.go
@@ -98,3 +98,24 @@ func getUserCreds(secret *k8sCore.Secret) (username, password string, err error)
 
 	return username, password, nil
 }
+
+func subnetsEqual(subnets1, subnets2 []string) bool {
+	if len(subnets1) != len(subnets2) {
+		return false
+	}
+
+	for _, s1 := range subnets1 {
+		var equal bool
+		for _, s2 := range subnets2 {
+			if s1 == s2 {
+				equal = true
+			}
+		}
+
+		if !equal {
+			return false
+		}
+	}
+
+	return true
+}

--- a/controllers/clusters/cassandra_controller.go
+++ b/controllers/clusters/cassandra_controller.go
@@ -229,13 +229,13 @@ func (r *CassandraReconciler) handleCreateCluster(
 			l.Error(err, "Cannot start cluster status job",
 				"cassandra cluster ID", cassandra.Status.ID)
 
-		r.EventRecorder.Eventf(
-			cassandra, models.Warning, models.CreationFailed,
-			"Cluster status check job is failed. Reason: %v",
-			err,
-		)
-		return reconcile.Result{}, err
-	}
+			r.EventRecorder.Eventf(
+				cassandra, models.Warning, models.CreationFailed,
+				"Cluster status check job is failed. Reason: %v",
+				err,
+			)
+			return reconcile.Result{}, err
+		}
 
 		r.EventRecorder.Eventf(
 			cassandra, models.Normal, models.Created,
@@ -248,13 +248,13 @@ func (r *CassandraReconciler) handleCreateCluster(
 				"cluster ID", cassandra.Status.ID,
 			)
 
-		r.EventRecorder.Eventf(
-			cassandra, models.Warning, models.CreationFailed,
-			"Cluster backups check job is failed. Reason: %v",
-			err,
-		)
-		return reconcile.Result{}, err
-	}
+			r.EventRecorder.Eventf(
+				cassandra, models.Warning, models.CreationFailed,
+				"Cluster backups check job is failed. Reason: %v",
+				err,
+			)
+			return reconcile.Result{}, err
+		}
 
 		r.EventRecorder.Eventf(
 			cassandra, models.Normal, models.Created,

--- a/pkg/instaclustr/client.go
+++ b/pkg/instaclustr/client.go
@@ -2181,6 +2181,37 @@ func (c *Client) UpdateClusterSettings(clusterID string, settings *models.Cluste
 	return nil
 }
 
+func (c *Client) GetAWSEndpointServicePrincipal(principalID string) (*models.AWSEndpointServicePrincipal, error) {
+	url := c.serverHostname + AWSEndpointServicePrincipalEndpoint + principalID
+
+	resp, err := c.DoRequest(url, http.MethodGet, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, NotFound
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code: %d, message: %s", resp.StatusCode, b)
+	}
+
+	var principal models.AWSEndpointServicePrincipal
+	err = json.Unmarshal(b, &principal)
+	if err != nil {
+		return nil, err
+	}
+
+	return &principal, nil
+}
+
 func (c *Client) CreateAWSEndpointServicePrincipal(spec any) ([]byte, error) {
 	url := c.serverHostname + AWSEndpointServicePrincipalEndpoint
 

--- a/pkg/instaclustr/interfaces.go
+++ b/pkg/instaclustr/interfaces.go
@@ -100,6 +100,7 @@ type API interface {
 	ListAppVersions(app string) ([]*models.AppVersions, error)
 	GetDefaultCredentialsV1(clusterID string) (string, string, error)
 	UpdateClusterSettings(clusterID string, settings *models.ClusterSettings) error
+	GetAWSEndpointServicePrincipal(id string) (*models.AWSEndpointServicePrincipal, error)
 	CreateAWSEndpointServicePrincipal(spec any) ([]byte, error)
 	DeleteAWSEndpointServicePrincipal(principalID string) error
 	GetResizeOperationsByClusterDataCentreID(cdcID string) ([]*v1beta1.ResizeOperation, error)

--- a/pkg/instaclustr/mock/client.go
+++ b/pkg/instaclustr/mock/client.go
@@ -375,3 +375,7 @@ func (c *mockClient) GetResizeOperationsByClusterDataCentreID(cdcID string) ([]*
 func (c *mockClient) GetAWSVPCPeering(peerID string) (*models.AWSVPCPeering, error) {
 	panic("GetAWSVPCPeering: is not implemented")
 }
+
+func (c *mockClient) GetAWSEndpointServicePrincipal(id string) (*models.AWSEndpointServicePrincipal, error) {
+	panic("GetAWSEndpointServicePrincipal: is not implemented")
+}

--- a/pkg/models/apiv2.go
+++ b/pkg/models/apiv2.go
@@ -20,6 +20,7 @@ const (
 	NoOperation         = "NO_OPERATION"
 	OperationInProgress = "OPERATION_IN_PROGRESS"
 
+	CreatedStatus = "CREATED"
 	DeletedStatus = "DELETED"
 
 	DefaultAccountName = "INSTACLUSTR"
@@ -204,4 +205,11 @@ type AWSVPCPeering struct {
 	PeerSubnets      []string `json:"peerSubnets"`
 	PeerVpcID        string   `json:"peerVpcId"`
 	StatusCode       string   `json:"statusCode"`
+}
+
+type AWSEndpointServicePrincipal struct {
+	ID                  string `json:"id,omitempty"`
+	ClusterDataCenterID string `json:"clusterDataCenterId,omitempty"`
+	EndPointServiceID   string `json:"endPointServiceId,omitempty"`
+	PrincipalARN        string `json:"principalArn,omitempty"`
 }

--- a/pkg/models/operator.go
+++ b/pkg/models/operator.go
@@ -157,6 +157,10 @@ const (
 	UpcomingME   = "upcoming"
 )
 
+const (
+	AWSVPCPeeringStatusCodeDeleted = "deleted"
+)
+
 const Requeue60 = time.Second * 60
 
 var (


### PR DESCRIPTION
# Issue 572

Added:
- handling of the external deletion of the resources on Instaclustr
- fixed external changes for VPC peering resources when Instaclustr API returns a list of subnets in a different order

closes #572 