### PR TITLE
Instaclustr APIv2 Cluster Settings Update for Redis

### DIFF
--- a/apis/clusters/v1beta1/cassandra_types.go
+++ b/apis/clusters/v1beta1/cassandra_types.go
@@ -303,6 +303,7 @@ func (cs *CassandraSpec) FromInstAPI(iCass *models.CassandraCluster) CassandraSp
 			PrivateNetworkCluster: iCass.PrivateNetworkCluster,
 			SLATier:               iCass.SLATier,
 			TwoFactorDelete:       cs.Cluster.TwoFactorDeleteFromInstAPI(iCass.TwoFactorDelete),
+			Description:           iCass.Description,
 		},
 		DataCentres:         cs.DCsFromInstAPI(iCass.DataCentres),
 		LuceneEnabled:       iCass.LuceneEnabled,
@@ -355,6 +356,7 @@ func (cs *CassandraSpec) ToInstAPI() *models.CassandraCluster {
 		PCIComplianceMode:     cs.PCICompliance,
 		TwoFactorDelete:       cs.TwoFactorDeletesToInstAPI(),
 		BundledUseOnly:        cs.BundledUseOnly,
+		Description:           cs.Description,
 		ResizeSettings:        resizeSettingsToInstAPI(cs.ResizeSettings),
 	}
 }

--- a/apis/clusters/v1beta1/redis_types.go
+++ b/apis/clusters/v1beta1/redis_types.go
@@ -68,8 +68,8 @@ type RedisSpec struct {
 	PasswordAndUserAuth bool `json:"passwordAndUserAuth,omitempty"`
 	//+kubebuilder:validation:MaxItems:=2
 	DataCentres []*RedisDataCentre `json:"dataCentres,omitempty"`
-	Description string             `json:"description,omitempty"`
-	UserRefs    []*UserReference   `json:"userRefs,omitempty"`
+
+	UserRefs []*UserReference `json:"userRefs,omitempty"`
 	//+kubebuilder:validation:MaxItems:=1
 	ResizeSettings []*ResizeSettings `json:"resizeSettings,omitempty"`
 }
@@ -157,6 +157,7 @@ func (rs *RedisSpec) ToInstAPI() *models.RedisCluster {
 		PrivateNetworkCluster:  rs.PrivateNetworkCluster,
 		PasswordAndUserAuth:    rs.PasswordAndUserAuth,
 		SLATier:                rs.SLATier,
+		Description:            rs.Description,
 		DataCentres:            rs.DCsToInstAPI(),
 		TwoFactorDelete:        rs.TwoFactorDeletesToInstAPI(),
 	}
@@ -273,11 +274,11 @@ func (rs *RedisSpec) FromInstAPI(iRedis *models.RedisCluster) RedisSpec {
 			PrivateNetworkCluster: iRedis.PrivateNetworkCluster,
 			SLATier:               iRedis.SLATier,
 			TwoFactorDelete:       rs.Cluster.TwoFactorDeleteFromInstAPI(iRedis.TwoFactorDelete),
+			Description:           iRedis.Description,
 		},
 		ClientEncryption:    iRedis.ClientToNodeEncryption,
 		PasswordAndUserAuth: iRedis.PasswordAndUserAuth,
 		DataCentres:         rs.DCsFromInstAPI(iRedis.DataCentres),
-		Description:         rs.Description,
 	}
 }
 

--- a/apis/clusters/v1beta1/structs.go
+++ b/apis/clusters/v1beta1/structs.go
@@ -324,15 +324,17 @@ func (c *Cluster) ClusterSettingsUpdateToInstAPI() (*models.ClusterSettings, err
 		return nil, models.ErrOnlyOneEntityTwoFactorDelete
 	}
 
-	iTFD := &models.TwoFactorDelete{}
-	for _, tfd := range c.TwoFactorDelete {
-		iTFD = tfd.ToInstAPI()
+	settingsToAPI := &models.ClusterSettings{}
+	if c.TwoFactorDelete != nil {
+		iTFD := &models.TwoFactorDelete{}
+		for _, tfd := range c.TwoFactorDelete {
+			iTFD = tfd.ToInstAPI()
+		}
+		settingsToAPI.TwoFactorDelete = iTFD
 	}
+	settingsToAPI.Description = c.Description
 
-	return &models.ClusterSettings{
-		Description:     c.Description,
-		TwoFactorDelete: iTFD,
-	}, nil
+	return settingsToAPI, nil
 }
 
 func (c *Cluster) TwoFactorDeleteToInstAPIv1() *models.TwoFactorDeleteV1 {

--- a/apis/clusters/v1beta1/validation.go
+++ b/apis/clusters/v1beta1/validation.go
@@ -35,6 +35,10 @@ func (c *Cluster) ValidateCreation() error {
 		return fmt.Errorf("two factor delete should not have more than 1 item")
 	}
 
+	if c.Description != "" {
+		return fmt.Errorf("description is not supported yet, when create a cluster. You can add this field when the cluster is in the running state")
+	}
+
 	if !validation.Contains(c.SLATier, models.SLATiers) {
 		return fmt.Errorf("cluster SLATier %s is unavailable, available values: %v",
 			c.SLATier, models.SLATiers)

--- a/controllers/clusters/cassandra_controller.go
+++ b/controllers/clusters/cassandra_controller.go
@@ -322,6 +322,10 @@ func (r *CassandraReconciler) handleUpdateCluster(
 
 	if len(cassandra.Spec.TwoFactorDelete) != 0 && len(iCassandra.Spec.TwoFactorDelete) == 0 ||
 		cassandra.Spec.Description != iCassandra.Spec.Description {
+		l.Info("Updating cluster settings",
+			"instaclustr description", iCassandra.Spec.Description,
+			"instaclustr two factor delete", iCassandra.Spec.TwoFactorDelete)
+
 		settingsToInstAPI, err := cassandra.Spec.ClusterSettingsUpdateToInstAPI()
 		if err != nil {
 			l.Error(err, "Cannot convert cluster settings to Instaclustr API",

--- a/pkg/models/apiv2.go
+++ b/pkg/models/apiv2.go
@@ -92,7 +92,7 @@ type Node struct {
 
 type TwoFactorDelete struct {
 	ConfirmationPhoneNumber string `json:"confirmationPhoneNumber,omitempty"`
-	ConfirmationEmail       string `json:"confirmationEmail"`
+	ConfirmationEmail       string `json:"confirmationEmail,omitempty"`
 }
 
 type NodeReloadStatus struct {
@@ -127,7 +127,7 @@ type PrivateLink struct {
 
 type ClusterSettings struct {
 	Description     string           `json:"description"`
-	TwoFactorDelete *TwoFactorDelete `json:"twoFactorDelete"`
+	TwoFactorDelete *TwoFactorDelete `json:"twoFactorDelete,omitempty"`
 }
 
 // ResizeSettings determines how resize requests will be performed for the cluster

--- a/pkg/models/cassandra_apiv2.go
+++ b/pkg/models/cassandra_apiv2.go
@@ -30,6 +30,7 @@ type CassandraCluster struct {
 	TwoFactorDelete       []*TwoFactorDelete     `json:"twoFactorDelete,omitempty"`
 	BundledUseOnly        bool                   `json:"bundledUseOnly,omitempty"`
 	ResizeSettings        []*ResizeSettings      `json:"resizeSettings"`
+	Description           string                 `json:"description"`
 }
 
 type CassandraDataCentre struct {

--- a/pkg/models/redis_apiv2.go
+++ b/pkg/models/redis_apiv2.go
@@ -27,6 +27,7 @@ type RedisCluster struct {
 	PasswordAndUserAuth    bool               `json:"passwordAndUserAuth"`
 	TwoFactorDelete        []*TwoFactorDelete `json:"twoFactorDelete,omitempty"`
 	SLATier                string             `json:"slaTier"`
+	Description            string             `json:"description"`
 }
 
 type RedisDataCentre struct {


### PR DESCRIPTION
- Fixed a generic `ClusterSettingsUpdateToInstAPI()` for new API v2 endpoint validation.
- Added workaround for when creating a cluster with a `description` field it returns an empty value. The bug is in progress on the Instaclustr API v2 team. For now, adding the `description` is only possible when updating a cluster.
- Added update cluster settings for Redis