### PR TITLE
issue-559, Cadence controller integration of the rate limiter

### DIFF
--- a/controllers/clusters/cadence_controller_test.go
+++ b/controllers/clusters/cadence_controller_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusters
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/instaclustr/operator/apis/clusters/v1beta1"
+	"github.com/instaclustr/operator/pkg/instaclustr"
+	mock "github.com/instaclustr/operator/pkg/instaclustr/mock/server/go"
+	"github.com/instaclustr/operator/pkg/models"
+)
+
+var _ = Describe("Cadence Controller", func() {
+	Context("Standard provisioning of cadence cluster", func() {
+		cadenceManifest := &v1beta1.Cadence{}
+
+		b, err := os.ReadFile(filepath.Join(".", "datatest", "cadence_v1beta1.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(yaml.Unmarshal(b, cadenceManifest)).Should(Succeed())
+
+		It("creates the cadence custom resource in k8s", func() {
+			Expect(k8sClient.Create(ctx, cadenceManifest)).Should(Succeed())
+
+			key := client.ObjectKeyFromObject(cadenceManifest)
+			cadence := &v1beta1.Cadence{}
+
+			expectedClusterID := cadenceManifest.Spec.Name + "-" + mock.CreatedID
+
+			Eventually(func() (string, error) {
+				if err := k8sClient.Get(ctx, key, cadence); err != nil {
+					return "", err
+				}
+
+				return cadence.Status.ID, nil
+			}, timeout, interval).Should(Equal(expectedClusterID))
+		})
+
+		It("updates node size of the existing cadence custom resource", func() {
+			key := client.ObjectKeyFromObject(cadenceManifest)
+			cadence := &v1beta1.Cadence{}
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, key, cadence)
+			}, timeout, interval).ShouldNot(HaveOccurred())
+
+			const newNodeSize = "cadence-test-node-size-2"
+
+			patch := cadence.NewPatch()
+			cadence.Spec.DataCentres[0].NodeSize = newNodeSize
+			Expect(k8sClient.Patch(ctx, cadence, patch)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, key, cadence)).Should(Succeed())
+
+				g.Expect(cadence.Status.DataCentres).ShouldNot(BeEmpty())
+				g.Expect(cadence.Status.DataCentres[0].Nodes).ShouldNot(BeEmpty())
+
+				g.Expect(cadence.Status.DataCentres[0].Nodes[0].Size).Should(Equal(newNodeSize))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("deletes the cadence resource in k8s and on Instaclustr", func() {
+			key := client.ObjectKeyFromObject(cadenceManifest)
+			cadence := &v1beta1.Cadence{}
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, key, cadence)).Should(Succeed(), "should get the cadence resource")
+				g.Expect(cadence.Status.ID).ShouldNot(BeEmpty(), "the cadence id should not be empty")
+			}, timeout, interval).Should(Succeed())
+
+			Expect(k8sClient.Delete(ctx, cadence)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				c := &v1beta1.Cadence{}
+				g.Expect(k8sClient.Get(ctx, key, c)).ShouldNot(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func() error {
+				_, err := instaClient.GetCadence(cadence.Status.ID)
+				return err
+			}, timeout, interval).Should(Equal(instaclustr.NotFound))
+		})
+	})
+
+	Context("Packaged provisioning of cadence cluster", func() {
+		cadenceManifest := &v1beta1.Cadence{}
+
+		b, err := os.ReadFile(filepath.Join(".", "datatest", "cadence_v1beta1_packaged.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(yaml.Unmarshal(b, cadenceManifest)).Should(Succeed())
+
+		It("creates a cadence and all packaged custom resources in k8s and on Instaclustr", func() {
+			Expect(k8sClient.Create(ctx, cadenceManifest)).Should(Succeed())
+
+			cadence := &v1beta1.Cadence{}
+			opensearch := &v1beta1.OpenSearch{}
+			kafka := &v1beta1.Kafka{}
+			cassandra := &v1beta1.Cassandra{}
+
+			key := client.ObjectKeyFromObject(cadenceManifest)
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, key, cadence)).Should(Succeed())
+				g.Expect(cadence.Status.ID).ShouldNot(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: metav1.NamespaceDefault,
+					Name:      models.OpenSearchChildPrefix + cadence.Name}, opensearch,
+				)
+			}, timeout, interval).Should(Succeed(), "should get opensearch resource")
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: metav1.NamespaceDefault,
+					Name:      models.CassandraChildPrefix + cadence.Name}, cassandra,
+				)
+			}, timeout, interval).Should(Succeed(), "should get cassandra resource")
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: metav1.NamespaceDefault,
+					Name:      models.KafkaChildPrefix + cadence.Name}, kafka,
+				)
+			}, timeout, interval).Should(Succeed(), "should get kafka resource")
+		})
+
+		It("deletes the cadence and bundled resources in k8s and Instaclustr", func() {
+			key := client.ObjectKeyFromObject(cadenceManifest)
+			cadence := &v1beta1.Cadence{}
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, key, cadence)).Should(Succeed(), "should get the cadence resource")
+				g.Expect(cadence.Status.ID).ShouldNot(BeEmpty(), "the cadence id should not be empty")
+			}, timeout, interval).Should(Succeed())
+
+			Expect(k8sClient.Delete(ctx, cadence)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				c := &v1beta1.Cadence{}
+				g.Expect(k8sClient.Get(ctx, key, c)).ShouldNot(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			opensearch := &v1beta1.OpenSearch{}
+			kafka := &v1beta1.Kafka{}
+			cassandra := &v1beta1.Cassandra{}
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: metav1.NamespaceDefault,
+					Name:      models.OpenSearchChildPrefix + cadence.Name}, opensearch,
+				)
+			}, timeout, interval).ShouldNot(Succeed(), "should not get opensearch resource")
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: metav1.NamespaceDefault,
+					Name:      models.CassandraChildPrefix + cadence.Name}, cassandra,
+				)
+			}, timeout, interval).ShouldNot(Succeed(), "should not get cassandra resource")
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: metav1.NamespaceDefault,
+					Name:      models.KafkaChildPrefix + cadence.Name}, kafka,
+				)
+			}, timeout, interval).ShouldNot(Succeed(), "should not get kafka resource")
+		})
+	})
+})

--- a/controllers/clusters/datatest/cadence_v1beta1.yaml
+++ b/controllers/clusters/datatest/cadence_v1beta1.yaml
@@ -1,0 +1,66 @@
+#apiVersion: v1
+#kind: Secret
+#metadata:
+#  name: inst-test-aws-cred-secret
+#data:
+#  awsAccessKeyId: access_key
+#  awsSecretAccessKey: secret_key
+#---
+apiVersion: clusters.instaclustr.com/v1beta1
+kind: Cadence
+metadata:
+  name: cadence-test
+  namespace: default
+  annotations:
+    defaulter: webhook
+spec:
+  name: "cadence-test"
+  version: "1.0.0"
+  standardProvisioning:
+      - targetCassandra:
+          dependencyCdcId: test-cassandra-cdcid
+          dependencyVpcType: "VPC_PEERED"
+#  packagedProvisioning:
+#    - bundledCassandraSpec:
+#        nodeSize: "CAS-DEV-t4g.small-5"
+#        network: "10.2.0.0/16"
+#        replicationFactor: 3
+#        nodesNumber: 3
+#        privateIPBroadcastForDiscovery: false
+#        passwordAndUserAuth: true
+  #      useAdvancedVisibility: true
+  #      bundledKafkaSpec:
+  #        nodeSize: "KFK-DEV-t4g.small-5"
+  #        nodesNumber: 3
+  #        network: "10.3.0.0/16"
+  #        replicationFactor: 3
+  #        partitionsNumber: 3
+  #      bundledOpenSearchSpec:
+  #        nodeSize: "SRH-DEV-t4g.small-5"
+  #        replicationFactor: 3
+  #        network: "10.4.0.0/16"
+  #  twoFactorDelete:
+  #    - email: "example@netapp.com"
+  privateNetworkCluster: false
+  dataCentres:
+    - region: "US_WEST_2"
+      network: "10.12.0.0/16"
+      # if you use multi-region mode please provide
+      # non-overlapping CIDR block for the secondary mode cluster
+      #      network: "10.16.0.0/16"
+      cloudProvider: "AWS_VPC"
+      name: "testdc"
+      #      nodeSize: "CAD-PRD-m5ad.large-75"
+      nodeSize: "cadence-test-node-size-1"
+      nodesNumber: 1
+      clientEncryption: false
+  #      privateLink:
+  #        - advertisedHostname: "cadence-sample-test.com"
+  slaTier: "NON_PRODUCTION"
+  useCadenceWebAuth: false
+  #  targetPrimaryCadence:
+  #    - dependencyCdcId: "cce79be3-7f41-4cad-837c-86d3d8b4be77"
+  #      dependencyVpcType: "SEPARATE_VPC"
+  resizeSettings:
+    - notifySupportContacts: false
+      concurrency: 1

--- a/controllers/clusters/datatest/cadence_v1beta1_packaged.yaml
+++ b/controllers/clusters/datatest/cadence_v1beta1_packaged.yaml
@@ -1,0 +1,66 @@
+#apiVersion: v1
+#kind: Secret
+#metadata:
+#  name: inst-test-aws-cred-secret
+#data:
+#  awsAccessKeyId: access_key
+#  awsSecretAccessKey: secret_key
+#---
+apiVersion: clusters.instaclustr.com/v1beta1
+kind: Cadence
+metadata:
+  name: cadence-test-packaged-provisioning
+  namespace: default
+  annotations:
+    defaulter: webhook
+spec:
+  name: "cadence-test"
+  version: "1.0.0"
+#  standardProvisioning:
+#      - targetCassandra:
+#          dependencyCdcId: test-cassandra-cdcid
+#          dependencyVpcType: "VPC_PEERED"
+  packagedProvisioning:
+    - bundledCassandraSpec:
+        nodeSize: "CAS-DEV-t4g.small-5"
+        network: "10.2.0.0/16"
+        replicationFactor: 3
+        nodesNumber: 3
+        privateIPBroadcastForDiscovery: false
+        passwordAndUserAuth: true
+      useAdvancedVisibility: true
+      bundledKafkaSpec:
+        nodeSize: "KFK-DEV-t4g.small-5"
+        nodesNumber: 3
+        network: "10.3.0.0/16"
+        replicationFactor: 3
+        partitionsNumber: 3
+      bundledOpenSearchSpec:
+        nodeSize: "SRH-DEV-t4g.small-5"
+        replicationFactor: 3
+        network: "10.4.0.0/16"
+  #  twoFactorDelete:
+  #    - email: "example@netapp.com"
+  privateNetworkCluster: false
+  dataCentres:
+    - region: "US_WEST_2"
+      network: "10.12.0.0/16"
+      # if you use multi-region mode please provide
+      # non-overlapping CIDR block for the secondary mode cluster
+      #      network: "10.16.0.0/16"
+      cloudProvider: "AWS_VPC"
+      name: "testdc"
+      #      nodeSize: "CAD-PRD-m5ad.large-75"
+      nodeSize: "cadence-test-node-size-1"
+      nodesNumber: 1
+      clientEncryption: false
+  #      privateLink:
+  #        - advertisedHostname: "cadence-sample-test.com"
+  slaTier: "NON_PRODUCTION"
+  useCadenceWebAuth: false
+  #  targetPrimaryCadence:
+  #    - dependencyCdcId: "cce79be3-7f41-4cad-837c-86d3d8b4be77"
+  #      dependencyVpcType: "SEPARATE_VPC"
+  resizeSettings:
+    - notifySupportContacts: false
+      concurrency: 1

--- a/controllers/clusters/suite_test.go
+++ b/controllers/clusters/suite_test.go
@@ -158,6 +158,15 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = (&CadenceReconciler{
+		Client:        k8sManager.GetClient(),
+		Scheme:        k8sManager.GetScheme(),
+		API:           instaClient,
+		Scheduler:     scheduler.NewScheduler(logf.Log),
+		EventRecorder: eRecorder,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	err = (&PostgreSQLReconciler{
 		Client:        k8sManager.GetClient(),
 		Scheme:        k8sManager.GetScheme(),

--- a/pkg/instaclustr/mock/server/go/api.go
+++ b/pkg/instaclustr/mock/server/go/api.go
@@ -562,6 +562,7 @@ type CadenceProvisioningV2APIServicer interface {
 	ClusterManagementV2ResourcesApplicationsCadenceClustersV2ClusterIdGet(context.Context, string) (ImplResponse, error)
 	ClusterManagementV2ResourcesApplicationsCadenceClustersV2ClusterIdPut(context.Context, string, CadenceClusterUpdateV2) (ImplResponse, error)
 	ClusterManagementV2ResourcesApplicationsCadenceClustersV2Post(context.Context, CadenceClusterV2) (ImplResponse, error)
+	ClusterManagementV2ResourcesApplicationsVersions(ctx context.Context, appKind string) (ImplResponse, error)
 }
 
 // ClusterExclusionWindowV2APIServicer defines the api actions for the ClusterExclusionWindowV2API service

--- a/pkg/instaclustr/mock/server/go/api_apache_cassandra_provisioning_v2_service.go
+++ b/pkg/instaclustr/mock/server/go/api_apache_cassandra_provisioning_v2_service.go
@@ -13,12 +13,14 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync"
 )
 
 // ApacheCassandraProvisioningV2APIService is a service that implements the logic for the ApacheCassandraProvisioningV2APIServicer
 // This service should implement the business logic for every endpoint for the ApacheCassandraProvisioningV2API API.
 // Include any external packages or services that will be required by this service.
 type ApacheCassandraProvisioningV2APIService struct {
+	mu       sync.RWMutex
 	clusters map[string]*CassandraClusterV2
 }
 
@@ -64,6 +66,9 @@ func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2OperationsA
 func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsCassandraClustersV2ClusterIdDelete(ctx context.Context, clusterId string) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsCassandraClustersV2ClusterIdDelete with the required logic for this service method.
 	// Add api_apache_cassandra_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	_, exists := s.clusters[clusterId]
 	if !exists {
 		return Response(http.StatusNotFound, nil), nil
@@ -78,6 +83,8 @@ func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2ResourcesAp
 func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsCassandraClustersV2ClusterIdGet(ctx context.Context, clusterId string) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsCassandraClustersV2ClusterIdGet with the required logic for this service method.
 	// Add api_apache_cassandra_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	c, exists := s.clusters[clusterId]
 	if !exists {
@@ -93,6 +100,8 @@ func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2ResourcesAp
 func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsCassandraClustersV2ClusterIdPut(ctx context.Context, clusterId string, cassandraClusterUpdateV2 CassandraClusterUpdateV2) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsCassandraClustersV2ClusterIdPut with the required logic for this service method.
 	// Add api_apache_cassandra_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	c, exists := s.clusters[clusterId]
 	if !exists {
@@ -114,12 +123,18 @@ func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2ResourcesAp
 func (s *ApacheCassandraProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsCassandraClustersV2Post(ctx context.Context, cassandraClusterV2 CassandraClusterV2) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsCassandraClustersV2Post with the required logic for this service method.
 	// Add api_apache_cassandra_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	newCassandra := &CassandraClusterV2{}
 
 	newCassandra = &cassandraClusterV2
 	newCassandra.Id = cassandraClusterV2.Name + CreatedID
 	newCassandra.DataCentres[0].Nodes = []NodeDetailsV2{{NodeSize: cassandraClusterV2.DataCentres[0].NodeSize}}
+
+	for i := range newCassandra.DataCentres {
+		newCassandra.DataCentres[i].Id = newCassandra.DataCentres[i].Name + "-" + CreatedID
+	}
 
 	s.clusters[newCassandra.Id] = newCassandra
 

--- a/pkg/instaclustr/mock/server/go/api_apache_kafka_provisioning_v2_service.go
+++ b/pkg/instaclustr/mock/server/go/api_apache_kafka_provisioning_v2_service.go
@@ -11,6 +11,7 @@ package openapi
 
 import (
 	"context"
+	"sync"
 )
 
 // ApacheKafkaProvisioningV2APIService is a service that implements the logic for the ApacheKafkaProvisioningV2APIServicer
@@ -18,6 +19,7 @@ import (
 // Include any external packages or services that will be required by this service.
 type ApacheKafkaProvisioningV2APIService struct {
 	clusters map[string]*KafkaClusterV2
+	mu       sync.RWMutex
 }
 
 // NewApacheKafkaProvisioningV2APIService creates a default api service
@@ -29,6 +31,8 @@ func NewApacheKafkaProvisioningV2APIService() ApacheKafkaProvisioningV2APIServic
 func (s *ApacheKafkaProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsKafkaClustersV2ClusterIdDelete(ctx context.Context, clusterId string) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsKafkaClustersV2ClusterIdDelete with the required logic for this service method.
 	// Add api_apache_kafka_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	delete(s.clusters, clusterId)
 	return Response(204, nil), nil
@@ -38,6 +42,8 @@ func (s *ApacheKafkaProvisioningV2APIService) ClusterManagementV2ResourcesApplic
 func (s *ApacheKafkaProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsKafkaClustersV2ClusterIdGet(ctx context.Context, clusterId string) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsKafkaClustersV2ClusterIdGet with the required logic for this service method.
 	// Add api_apache_kafka_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	cluster, exists := s.clusters[clusterId]
 	if !exists {
@@ -53,6 +59,8 @@ func (s *ApacheKafkaProvisioningV2APIService) ClusterManagementV2ResourcesApplic
 func (s *ApacheKafkaProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsKafkaClustersV2ClusterIdPut(ctx context.Context, clusterId string, kafkaClusterUpdateV2 KafkaClusterUpdateV2) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsKafkaClustersV2ClusterIdPut with the required logic for this service method.
 	// Add api_apache_kafka_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	cluster, exists := s.clusters[clusterId]
 	if !exists {
@@ -78,8 +86,15 @@ func (s *ApacheKafkaProvisioningV2APIService) ClusterManagementV2ResourcesApplic
 func (s *ApacheKafkaProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsKafkaClustersV2Post(ctx context.Context, kafkaClusterV2 KafkaClusterV2) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsKafkaClustersV2Post with the required logic for this service method.
 	// Add api_apache_kafka_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	kafkaClusterV2.Id = kafkaClusterV2.Name + CreatedID
+
+	for i := range kafkaClusterV2.DataCentres {
+		kafkaClusterV2.DataCentres[i].Id = kafkaClusterV2.DataCentres[i].Name + "-" + CreatedID
+	}
+
 	s.clusters[kafkaClusterV2.Id] = &kafkaClusterV2
 
 	return Response(202, kafkaClusterV2), nil

--- a/pkg/instaclustr/mock/server/go/api_cadence_provisioning_v2.go
+++ b/pkg/instaclustr/mock/server/go/api_cadence_provisioning_v2.go
@@ -70,6 +70,11 @@ func (c *CadenceProvisioningV2APIController) Routes() Routes {
 			"/cluster-management/v2/resources/applications/cadence/clusters/v2/",
 			c.ClusterManagementV2ResourcesApplicationsCadenceClustersV2Post,
 		},
+		"ClusterManagementV2ResourcesApplicationsVersions": Route{
+			strings.ToUpper("Get"),
+			"/cluster-management/v2/data-sources/applications/{appKind}/versions/v2/",
+			c.ClusterManagementV2ResourcesApplicationsVersions,
+		},
 	}
 }
 
@@ -153,6 +158,20 @@ func (c *CadenceProvisioningV2APIController) ClusterManagementV2ResourcesApplica
 		c.errorHandler(w, r, err, &result)
 		return
 	}
+	// If no error, encode the body and the result code
+	EncodeJSONResponse(result.Body, &result.Code, w)
+}
+
+func (c *CadenceProvisioningV2APIController) ClusterManagementV2ResourcesApplicationsVersions(w http.ResponseWriter, r *http.Request) {
+	appKind := mux.Vars(r)["appKind"]
+
+	result, err := c.service.ClusterManagementV2ResourcesApplicationsVersions(r.Context(), appKind)
+	// If an error occurred, encode the error with the status code
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+
 	// If no error, encode the body and the result code
 	EncodeJSONResponse(result.Body, &result.Code, w)
 }

--- a/pkg/instaclustr/mock/server/go/api_open_search_provisioning_v2_service.go
+++ b/pkg/instaclustr/mock/server/go/api_open_search_provisioning_v2_service.go
@@ -13,12 +13,14 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync"
 )
 
 // OpenSearchProvisioningV2APIService is a service that implements the logic for the OpenSearchProvisioningV2APIServicer
 // This service should implement the business logic for every endpoint for the OpenSearchProvisioningV2API API.
 // Include any external packages or services that will be required by this service.
 type OpenSearchProvisioningV2APIService struct {
+	mu       sync.RWMutex
 	clusters map[string]*OpenSearchClusterV2
 }
 
@@ -64,6 +66,8 @@ func (s *OpenSearchProvisioningV2APIService) ClusterManagementV2OperationsApplic
 func (s *OpenSearchProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsOpensearchClustersV2ClusterIdDelete(ctx context.Context, clusterId string) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsOpensearchClustersV2ClusterIdDelete with the required logic for this service method.
 	// Add api_open_search_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	_, exists := s.clusters[clusterId]
 	if !exists {
@@ -79,6 +83,8 @@ func (s *OpenSearchProvisioningV2APIService) ClusterManagementV2ResourcesApplica
 func (s *OpenSearchProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsOpensearchClustersV2ClusterIdGet(ctx context.Context, clusterId string) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsOpensearchClustersV2ClusterIdGet with the required logic for this service method.
 	// Add api_open_search_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	o, exists := s.clusters[clusterId]
 	if !exists {
@@ -94,6 +100,8 @@ func (s *OpenSearchProvisioningV2APIService) ClusterManagementV2ResourcesApplica
 func (s *OpenSearchProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsOpensearchClustersV2ClusterIdPut(ctx context.Context, clusterId string, openSearchClusterUpdateV2 OpenSearchClusterUpdateV2) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsOpensearchClustersV2ClusterIdPut with the required logic for this service method.
 	// Add api_open_search_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	o, exists := s.clusters[clusterId]
 	if !exists {
@@ -114,11 +122,17 @@ func (s *OpenSearchProvisioningV2APIService) ClusterManagementV2ResourcesApplica
 func (s *OpenSearchProvisioningV2APIService) ClusterManagementV2ResourcesApplicationsOpensearchClustersV2Post(ctx context.Context, openSearchClusterV2 OpenSearchClusterV2) (ImplResponse, error) {
 	// TODO - update ClusterManagementV2ResourcesApplicationsOpensearchClustersV2Post with the required logic for this service method.
 	// Add api_open_search_provisioning_v2_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	newOpenSearch := &OpenSearchClusterV2{}
 
 	newOpenSearch = &openSearchClusterV2
 	newOpenSearch.Id = openSearchClusterV2.Name + CreatedID
+
+	for i := range newOpenSearch.DataCentres {
+		newOpenSearch.DataCentres[i].Id = newOpenSearch.DataCentres[i].Name + "-" + CreatedID
+	}
 
 	s.clusters[newOpenSearch.Id] = newOpenSearch
 

--- a/pkg/instaclustr/mock/server/go/routers.go
+++ b/pkg/instaclustr/mock/server/go/routers.go
@@ -12,13 +12,14 @@ package openapi
 import (
 	"encoding/json"
 	"errors"
-	"github.com/gorilla/mux"
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/gorilla/mux"
 )
 
 // A Route defines the parameters for an api endpoint


### PR DESCRIPTION
Our custom rate limiter, which allows rate-limiting the amount of reconciliation for resources, was integrated into the cadence controller.

Also, the cadence controller was covered with integration tests.