### PR TITLE
Issue-599, Handle of deleting default secret for KafkaConnect and Zookeeper resources

### DIFF
--- a/controllers/clusters/kafkaconnect_controller.go
+++ b/controllers/clusters/kafkaconnect_controller.go
@@ -392,6 +392,15 @@ func (r *KafkaConnectReconciler) handleDeleteCluster(ctx context.Context, kc *v1
 		}
 	}
 
+	err = deleteDefaultUserSecret(ctx, r.Client, client.ObjectKeyFromObject(kc))
+	if err != nil {
+		l.Error(err, "Cannot delete default user secret")
+		r.EventRecorder.Eventf(kc, models.Warning, models.DeletionFailed,
+			"Deletion of the secret with default user credentials is failed. Reason: %w", err)
+
+		return reconcile.Result{}, err
+	}
+
 	r.Scheduler.RemoveJob(kc.GetJobID(scheduler.StatusChecker))
 	controllerutil.RemoveFinalizer(kc, models.DeletionFinalizer)
 	kc.Annotations[models.ResourceStateAnnotation] = models.DeletedEvent

--- a/controllers/clusters/zookeeper_controller.go
+++ b/controllers/clusters/zookeeper_controller.go
@@ -384,6 +384,15 @@ func (r *ZookeeperReconciler) handleDeleteCluster(
 		}
 	}
 
+	err = deleteDefaultUserSecret(ctx, r.Client, client.ObjectKeyFromObject(zook))
+	if err != nil {
+		l.Error(err, "Cannot delete default user secret")
+		r.EventRecorder.Eventf(zook, models.Warning, models.DeletionFailed,
+			"Deletion of the secret with default user credentials is failed. Reason: %w", err)
+
+		return reconcile.Result{}, err
+	}
+
 	r.Scheduler.RemoveJob(zook.GetJobID(scheduler.StatusChecker))
 	controllerutil.RemoveFinalizer(zook, models.DeletionFinalizer)
 	zook.Annotations[models.ResourceStateAnnotation] = models.DeletedEvent


### PR DESCRIPTION
In our previous implementation when Zookeeper or KafkaConnect resource is deleted it keeps secret with its default user credentials in k8s. It causes problems when we create KafkaConnect cluster, delete it, and create it again.
Now controllers delete the secrets of the resources during deletion operation.

ref #599