### PR TITLE
Two-factor delete enhancement

### DIFF
--- a/controllers/clusters/cadence_controller.go
+++ b/controllers/clusters/cadence_controller.go
@@ -794,6 +794,11 @@ func (r *CadenceReconciler) newWatchStatusJob(cadence *v1beta1.Cadence) schedule
 		iData, err := r.API.GetCadence(cadence.Status.ID)
 		if err != nil {
 			if errors.Is(err, instaclustr.NotFound) {
+				if cadence.DeletionTimestamp != nil {
+					_, err = r.HandleDeleteCluster(context.Background(), cadence, l)
+					return err
+				}
+
 				return r.handleExternalDelete(context.Background(), cadence)
 			}
 

--- a/controllers/clusters/cassandra_controller.go
+++ b/controllers/clusters/cassandra_controller.go
@@ -880,6 +880,11 @@ func (r *CassandraReconciler) newWatchStatusJob(cassandra *v1beta1.Cassandra) sc
 		iData, err := r.API.GetCassandra(cassandra.Status.ID)
 		if err != nil {
 			if errors.Is(err, instaclustr.NotFound) {
+				if cassandra.DeletionTimestamp != nil {
+					_, err = r.handleDeleteCluster(context.Background(), l, cassandra)
+					return err
+				}
+
 				return r.handleExternalDelete(context.Background(), cassandra)
 			}
 

--- a/controllers/clusters/kafka_controller.go
+++ b/controllers/clusters/kafka_controller.go
@@ -711,6 +711,11 @@ func (r *KafkaReconciler) newWatchStatusJob(kafka *v1beta1.Kafka) scheduler.Job 
 		iData, err := r.API.GetKafka(kafka.Status.ID)
 		if err != nil {
 			if errors.Is(err, instaclustr.NotFound) {
+				if kafka.DeletionTimestamp != nil {
+					_, err = r.handleDeleteCluster(context.Background(), kafka, l)
+					return err
+				}
+
 				return r.handleExternalDelete(context.Background(), kafka)
 			}
 

--- a/controllers/clusters/kafkaconnect_controller.go
+++ b/controllers/clusters/kafkaconnect_controller.go
@@ -503,6 +503,11 @@ func (r *KafkaConnectReconciler) newWatchStatusJob(kc *v1beta1.KafkaConnect) sch
 		iData, err := r.API.GetKafkaConnect(kc.Status.ID)
 		if err != nil {
 			if errors.Is(err, instaclustr.NotFound) {
+				if kc.DeletionTimestamp != nil {
+					_, err = r.handleDeleteCluster(context.Background(), kc, l)
+					return err
+				}
+
 				return r.handleExternalDelete(context.Background(), kc)
 			}
 

--- a/controllers/clusters/opensearch_controller.go
+++ b/controllers/clusters/opensearch_controller.go
@@ -618,6 +618,11 @@ func (r *OpenSearchReconciler) newWatchStatusJob(o *v1beta1.OpenSearch) schedule
 		iData, err := r.API.GetOpenSearch(o.Status.ID)
 		if err != nil {
 			if errors.Is(err, instaclustr.NotFound) {
+				if o.DeletionTimestamp != nil {
+					_, err = r.HandleDeleteCluster(context.Background(), o, l)
+					return err
+				}
+
 				return r.handleExternalDelete(context.Background(), o)
 			}
 

--- a/controllers/clusters/postgresql_controller.go
+++ b/controllers/clusters/postgresql_controller.go
@@ -1106,6 +1106,11 @@ func (r *PostgreSQLReconciler) newWatchStatusJob(pg *v1beta1.PostgreSQL) schedul
 		instPGData, err := r.API.GetPostgreSQL(pg.Status.ID)
 		if err != nil {
 			if errors.Is(err, instaclustr.NotFound) {
+				if pg.DeletionTimestamp != nil {
+					_, err = r.handleDeleteCluster(context.Background(), pg, l)
+					return err
+				}
+
 				return r.handleExternalDelete(context.Background(), pg)
 			}
 

--- a/controllers/clusters/redis_controller.go
+++ b/controllers/clusters/redis_controller.go
@@ -916,6 +916,11 @@ func (r *RedisReconciler) newWatchStatusJob(redis *v1beta1.Redis) scheduler.Job 
 		iData, err := r.API.GetRedis(redis.Status.ID)
 		if err != nil {
 			if errors.Is(err, instaclustr.NotFound) {
+				if redis.DeletionTimestamp != nil {
+					_, err = r.handleDeleteCluster(context.Background(), redis, l)
+					return err
+				}
+
 				return r.handleExternalDelete(context.Background(), redis)
 			}
 

--- a/controllers/clusters/zookeeper_controller.go
+++ b/controllers/clusters/zookeeper_controller.go
@@ -461,6 +461,11 @@ func (r *ZookeeperReconciler) newWatchStatusJob(zook *v1beta1.Zookeeper) schedul
 		iData, err := r.API.GetZookeeper(zook.Status.ID)
 		if err != nil {
 			if errors.Is(err, instaclustr.NotFound) {
+				if zook.DeletionTimestamp != nil {
+					_, err = r.handleDeleteCluster(context.Background(), zook, l)
+					return err
+				}
+
 				return r.handleExternalDelete(context.Background(), zook)
 			}
 


### PR DESCRIPTION
The previous way of handling two-factor deletion doesn't manage the case when a customer refuses the deletion of a resource for some reason. This PR fixes the problem by adding a single check in `statusChecker`'s of each cluster resource.