### PR TITLE
Integration tests for clusterreosurces group

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -837,32 +837,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - kubevirt.io
-  resources:
-  - virtualmachineinstances
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - kubevirt.io
-  resources:
-  - virtualmachines
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - kafkamanagement.instaclustr.com
   resources:
   - usercertificates
@@ -888,3 +862,29 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachineinstances
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/clusterresources/awsencryptionkey_controller.go
+++ b/controllers/clusterresources/awsencryptionkey_controller.go
@@ -229,9 +229,9 @@ func (r *AWSEncryptionKeyReconciler) handleDelete(
 	}
 
 	r.Scheduler.RemoveJob(encryptionKey.GetJobID(scheduler.StatusChecker))
+	patch := encryptionKey.NewPatch()
 	controllerutil.RemoveFinalizer(encryptionKey, models.DeletionFinalizer)
 	encryptionKey.Annotations[models.ResourceStateAnnotation] = models.DeletedEvent
-	patch := encryptionKey.NewPatch()
 	err = r.Patch(ctx, encryptionKey, patch)
 	if err != nil {
 		l.Error(err, "Cannot patch AWS encryption key metadata",

--- a/controllers/clusterresources/awsencryptionkey_controller_test.go
+++ b/controllers/clusterresources/awsencryptionkey_controller_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterresources
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/instaclustr/operator/apis/clusterresources/v1beta1"
+	"github.com/instaclustr/operator/pkg/instaclustr"
+	"github.com/instaclustr/operator/pkg/models"
+)
+
+var _ = Describe("AWSEncryptionKey controller", Ordered, func() {
+	awsEncryptionKey := &v1beta1.AWSEncryptionKey{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-encryption-key-test",
+			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				"instaclustr.com/test": "true",
+			},
+		},
+		Spec: v1beta1.AWSEncryptionKeySpec{
+			Alias: "test",
+			ARN:   "arn:aws:kms:us-east-1:152668027680:key/460b469b-9f0a-4801-854a-e23626957d00",
+		},
+	}
+
+	key := client.ObjectKeyFromObject(awsEncryptionKey)
+
+	When("Apply AWSEncryptionKey manifest", func() {
+		It("Should send API call to create the resource", func() {
+			Expect(k8sClient.Create(ctx, awsEncryptionKey)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, key, awsEncryptionKey)).Should(Succeed())
+				g.Expect(awsEncryptionKey.Finalizers).Should(ContainElement(models.DeletionFinalizer))
+				g.Expect(awsEncryptionKey.Status.ID).ShouldNot(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	When("Delete AWSEncryptionKey k8s resource", func() {
+		It("Should send API call to delete the resource and delete resource in k8s", FlakeAttempts(3), func() {
+			id := awsEncryptionKey.Status.ID
+
+			By("sending delete request to k8s")
+			Expect(k8sClient.Delete(ctx, awsEncryptionKey)).Should(Succeed())
+
+			By("checking if resource exists on the Instaclustr API")
+			Eventually(func() error {
+				_, err := instaClient.GetEncryptionKeyStatus(id, instaclustr.AWSEncryptionKeyEndpoint)
+				return err
+			}, timeout, interval).Should(Equal(instaclustr.NotFound))
+
+			By("checking if the resource exists in k8s")
+			Eventually(func() bool {
+				var resource v1beta1.AWSEncryptionKey
+				return errors.IsNotFound(k8sClient.Get(ctx, key, &resource))
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+})

--- a/controllers/clusterresources/awsendpointserviceprincipal_controller_test.go
+++ b/controllers/clusterresources/awsendpointserviceprincipal_controller_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterresources
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/instaclustr/operator/apis/clusterresources/v1beta1"
+	"github.com/instaclustr/operator/pkg/instaclustr"
+	"github.com/instaclustr/operator/pkg/models"
+)
+
+var _ = Describe("AWSEndpointServicePrincipal controller", Ordered, func() {
+	awsEndpointServicePrincipal := &v1beta1.AWSEndpointServicePrincipal{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-endpoint-service-principal-test",
+			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				"instaclustr.com/test": "true",
+			},
+		},
+		Spec: v1beta1.AWSEndpointServicePrincipalSpec{
+			ClusterDataCenterID: "test-cluster-dc-id",
+			PrincipalARN:        "arn:aws:iam::152668027680:role/aws-principal-test-1",
+		},
+	}
+
+	key := client.ObjectKeyFromObject(awsEndpointServicePrincipal)
+
+	When("Apply awsEndpointServicePrincipal manifest", func() {
+		It("Should send API call to create the resource", func() {
+			Expect(k8sClient.Create(ctx, awsEndpointServicePrincipal)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, key, awsEndpointServicePrincipal)).Should(Succeed())
+				g.Expect(awsEndpointServicePrincipal.Finalizers).Should(ContainElement(models.DeletionFinalizer))
+				g.Expect(awsEndpointServicePrincipal.Status.ID).ShouldNot(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	When("Delete AWSEndpointServicePrincipal k8s resource", func() {
+		It("Should send API call to delete the resource and delete resource in k8s", FlakeAttempts(3), func() {
+			id := awsEndpointServicePrincipal.Status.ID
+
+			By("sending delete request to k8s")
+			Expect(k8sClient.Delete(ctx, awsEndpointServicePrincipal)).Should(Succeed())
+
+			By("checking if resource exists on the Instaclustr API")
+			Eventually(func() error {
+				_, err := instaClient.GetAWSEndpointServicePrincipal(id)
+				return err
+			}, timeout, interval).Should(Equal(instaclustr.NotFound))
+
+			By("checking if the resource exists in k8s")
+			Eventually(func() bool {
+				var resource v1beta1.AWSEndpointServicePrincipal
+				return errors.IsNotFound(k8sClient.Get(ctx, key, &resource))
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+})

--- a/controllers/clusterresources/awssecuritygroupfirewallrule_controller_test.go
+++ b/controllers/clusterresources/awssecuritygroupfirewallrule_controller_test.go
@@ -17,52 +17,76 @@ limitations under the License.
 package clusterresources
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/instaclustr/operator/apis/clusterresources/v1beta1"
-	"github.com/instaclustr/operator/pkg/instaclustr/mock"
+	"github.com/instaclustr/operator/pkg/instaclustr"
 	"github.com/instaclustr/operator/pkg/models"
 )
 
-var _ = Describe("Successful creation of a AWS Security Group Firewall Rule resource", func() {
+var _ = Describe("AWSSecurityGroupFirewallRule controller", Ordered, func() {
+	awsSGFirewallRuleSpec := v1beta1.AWSSecurityGroupFirewallRuleSpec{
+		FirewallRuleSpec: v1beta1.FirewallRuleSpec{
+			ClusterID: "375e4d1c-2f77-4d02-a6f2-1af617ff2ab2",
+			Type:      "SECURITY",
+		},
+		SecurityGroupID: "sg-1434412",
+	}
+	resource := v1beta1.AWSSecurityGroupFirewallRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "awssgfwrule",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"instaclustr.com/test": "true",
+			},
+		},
+		Spec: awsSGFirewallRuleSpec,
+	}
+
+	key := types.NamespacedName{Name: resource.Name, Namespace: resource.Namespace}
+
 	Context("When setting up a AWS Security Group Firewall Rule CRD", func() {
-		awsSGFirewallRuleSpec := v1beta1.AWSSecurityGroupFirewallRuleSpec{
-			FirewallRuleSpec: v1beta1.FirewallRuleSpec{
-				ClusterID: "375e4d1c-2f77-4d02-a6f2-1af617ff2ab2",
-				Type:      "SECURITY",
-			},
-			SecurityGroupID: "sg-1434412",
-		}
-
-		ctx := context.Background()
-		resource := v1beta1.AWSSecurityGroupFirewallRule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "awssgfwrule",
-				Namespace: "default",
-				Annotations: map[string]string{
-					models.ResourceStateAnnotation: models.CreatingEvent,
-				},
-			},
-			Spec: awsSGFirewallRuleSpec,
-		}
-
 		It("Should create a AWS Security Group Firewall Rule resources", func() {
 			Expect(k8sClient.Create(ctx, &resource)).Should(Succeed())
 
 			By("Sending AWS Security Group Firewall Rule Specification to Instaclustr API v2")
-			var awsSGFirewallRule v1beta1.AWSSecurityGroupFirewallRule
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "awssgfwrule", Namespace: "default"}, &awsSGFirewallRule); err != nil {
+				if err := k8sClient.Get(ctx, key, &resource); err != nil {
 					return false
 				}
 
-				return awsSGFirewallRule.Status.ID == mock.StatusID
+				if !controllerutil.ContainsFinalizer(&resource, models.DeletionFinalizer) {
+					return false
+				}
+
+				return resource.Status.ID != ""
 			}).Should(BeTrue())
+		})
+	})
+
+	Context("When deleting AWSSecurityGroupFirewallRule k8s resource", func() {
+		It("Should delete the resource in k8s and API", FlakeAttempts(3), func() {
+			id := resource.Status.ID
+
+			By("sending delete request to k8s")
+			Expect(k8sClient.Delete(ctx, &resource)).Should(Succeed())
+
+			By("checking if resource exists on the Instaclustr API")
+			Eventually(func() error {
+				_, err := instaClient.GetFirewallRuleStatus(id, instaclustr.AWSSecurityGroupFirewallRuleEndpoint)
+				return err
+			}, timeout, interval).Should(Equal(instaclustr.NotFound))
+
+			By("checking if the resource exists in k8s")
+			Eventually(func() bool {
+				var resource v1beta1.AWSSecurityGroupFirewallRule
+				return errors.IsNotFound(k8sClient.Get(ctx, key, &resource))
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 })

--- a/controllers/clusterresources/azurevnetpeering_controller.go
+++ b/controllers/clusterresources/azurevnetpeering_controller.go
@@ -247,7 +247,6 @@ func (r *AzureVNetPeeringReconciler) handleDeletePeering(
 			azure, models.Normal, models.DeletionStarted,
 			"Resource deletion request is sent",
 		)
-		return ctrl.Result{}, err
 	}
 
 	patch := azure.NewPatch()

--- a/controllers/clusterresources/azurevnetpeering_controller_test.go
+++ b/controllers/clusterresources/azurevnetpeering_controller_test.go
@@ -21,51 +21,79 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/instaclustr/operator/apis/clusterresources/v1beta1"
-	"github.com/instaclustr/operator/pkg/instaclustr/mock"
+	"github.com/instaclustr/operator/pkg/instaclustr"
 	"github.com/instaclustr/operator/pkg/models"
 )
 
-var _ = Describe("Successful creation of a Azure VNet Peering resource", func() {
+var _ = Describe("AzureVNetPeering controller", Ordered, func() {
+	azureVNetPeeringSpec := v1beta1.AzureVNetPeeringSpec{
+		VPCPeeringSpec: v1beta1.VPCPeeringSpec{
+			DataCentreID: "375e4d1c-2f77-4d02-a6f2-1af617ff2ab2",
+			PeerSubnets:  []string{"172.31.0.0/16", "192.168.0.0/16"},
+		},
+		PeerResourceGroup:      "rg-1231212",
+		PeerSubscriptionID:     "sg-123321",
+		PeerADObjectID:         "ad-132313",
+		PeerVirtualNetworkName: "vnet-123123123",
+	}
+
+	ctx := context.Background()
+	resource := v1beta1.AzureVNetPeering{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azurevnetpeering",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"instaclustr.com/test": "true",
+			},
+		},
+		Spec: azureVNetPeeringSpec,
+	}
+
+	key := client.ObjectKeyFromObject(&resource)
+
 	Context("When setting up a Azure VNet Peering CRD", func() {
-		azureVNetPeeringSpec := v1beta1.AzureVNetPeeringSpec{
-			VPCPeeringSpec: v1beta1.VPCPeeringSpec{
-				DataCentreID: "375e4d1c-2f77-4d02-a6f2-1af617ff2ab2",
-				PeerSubnets:  []string{"172.31.0.0/16", "192.168.0.0/16"},
-			},
-			PeerResourceGroup:      "rg-1231212",
-			PeerSubscriptionID:     "sg-123321",
-			PeerADObjectID:         "ad-132313",
-			PeerVirtualNetworkName: "vnet-123123123",
-		}
-
-		ctx := context.Background()
-		resource := v1beta1.AzureVNetPeering{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "azurevnetpeering",
-				Namespace: "default",
-				Annotations: map[string]string{
-					models.ResourceStateAnnotation: models.CreatingEvent,
-				},
-			},
-			Spec: azureVNetPeeringSpec,
-		}
-
 		It("Should create a Azure VNet Peering resources", func() {
 			Expect(k8sClient.Create(ctx, &resource)).Should(Succeed())
 
 			By("Sending Azure VNet Peering Specification to Instaclustr API v2")
-			var azureVNetPeering v1beta1.AzureVNetPeering
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "azurevnetpeering", Namespace: "default"}, &azureVNetPeering); err != nil {
+				if err := k8sClient.Get(ctx, key, &resource); err != nil {
 					return false
 				}
 
-				return azureVNetPeering.Status.ID == mock.StatusID
+				if !controllerutil.ContainsFinalizer(&resource, models.DeletionFinalizer) {
+					return false
+				}
+
+				return resource.Status.ID != ""
 			}).Should(BeTrue())
+		})
+	})
+
+	Context("When deleting AzureVNetPeering k8s resource", func() {
+		It("Should delete the resource in k8s and API", FlakeAttempts(3), func() {
+			id := resource.Status.ID
+
+			By("sending delete request to k8s")
+			Expect(k8sClient.Delete(ctx, &resource)).Should(Succeed())
+
+			By("checking if resource exists on the Instaclustr API")
+			Eventually(func() error {
+				_, err := instaClient.GetPeeringStatus(id, instaclustr.AzurePeeringEndpoint)
+				return err
+			}, timeout, interval).Should(Equal(instaclustr.NotFound))
+
+			By("checking if the resource exists in k8s")
+			Eventually(func() bool {
+				var resource v1beta1.AzureVNetPeering
+				return errors.IsNotFound(k8sClient.Get(ctx, key, &resource))
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 })

--- a/controllers/clusterresources/clusternetworkfirewallrule_controller_test.go
+++ b/controllers/clusterresources/clusternetworkfirewallrule_controller_test.go
@@ -21,48 +21,76 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/instaclustr/operator/apis/clusterresources/v1beta1"
-	"github.com/instaclustr/operator/pkg/instaclustr/mock"
+	"github.com/instaclustr/operator/pkg/instaclustr"
 	"github.com/instaclustr/operator/pkg/models"
 )
 
-var _ = Describe("Successful creation of a Cluster Network Firewall Rule resource", func() {
+var _ = Describe("Successful creation of a Cluster Network Firewall Rule resource", Ordered, func() {
+	clusterNetworkFirewallRuleSpec := v1beta1.ClusterNetworkFirewallRuleSpec{
+		FirewallRuleSpec: v1beta1.FirewallRuleSpec{
+			ClusterID: "375e4d1c-2f77-4d02-a6f2-1af617ff2ab2",
+			Type:      "SECURITY",
+		},
+		Network: "191.54.123.1/24",
+	}
+
+	ctx := context.Background()
+	resource := v1beta1.ClusterNetworkFirewallRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "clusternetworkfwrule",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"instaclustr.com/test": "true",
+			},
+		},
+		Spec: clusterNetworkFirewallRuleSpec,
+	}
+
+	key := client.ObjectKeyFromObject(&resource)
+
 	Context("When setting up a Cluster Network Firewall Rule CRD", func() {
-		clusterNetworkFirewallRuleSpec := v1beta1.ClusterNetworkFirewallRuleSpec{
-			FirewallRuleSpec: v1beta1.FirewallRuleSpec{
-				ClusterID: "375e4d1c-2f77-4d02-a6f2-1af617ff2ab2",
-				Type:      "SECURITY",
-			},
-			Network: "191.54.123.1/24",
-		}
-
-		ctx := context.Background()
-		resource := v1beta1.ClusterNetworkFirewallRule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "clusternetworkfwrule",
-				Namespace: "default",
-				Annotations: map[string]string{
-					models.ResourceStateAnnotation: models.CreatingEvent,
-				},
-			},
-			Spec: clusterNetworkFirewallRuleSpec,
-		}
-
 		It("Should create a Cluster Network Firewall Rule resources", func() {
 			Expect(k8sClient.Create(ctx, &resource)).Should(Succeed())
 
 			By("Sending Cluster Network Firewall Rule Specification to Instaclustr API v2")
-			var clusterNetworkFirewallRule v1beta1.ClusterNetworkFirewallRule
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "clusternetworkfwrule", Namespace: "default"}, &clusterNetworkFirewallRule); err != nil {
+				if err := k8sClient.Get(ctx, key, &resource); err != nil {
 					return false
 				}
 
-				return clusterNetworkFirewallRule.Status.ID == mock.StatusID
+				if !controllerutil.ContainsFinalizer(&resource, models.DeletionFinalizer) {
+					return false
+				}
+
+				return resource.Status.ID != ""
 			}).Should(BeTrue())
+		})
+	})
+
+	Context("When deleting ClusterNetworkFirewallRule k8s resource", func() {
+		It("Should delete the resource in k8s and API", FlakeAttempts(3), func() {
+			id := resource.Status.ID
+
+			By("sending delete request to k8s")
+			Expect(k8sClient.Delete(ctx, &resource)).Should(Succeed())
+
+			By("checking if resource exists on the Instaclustr API")
+			Eventually(func() error {
+				_, err := instaClient.GetFirewallRuleStatus(id, instaclustr.ClusterNetworkFirewallRuleEndpoint)
+				return err
+			}, timeout, interval).Should(Equal(instaclustr.NotFound))
+
+			By("checking if the resource exists in k8s")
+			Eventually(func() bool {
+				var resource v1beta1.ClusterNetworkFirewallRule
+				return errors.IsNotFound(k8sClient.Get(ctx, key, &resource))
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 })

--- a/controllers/clusterresources/gcpvpcpeering_controller_test.go
+++ b/controllers/clusterresources/gcpvpcpeering_controller_test.go
@@ -21,49 +21,77 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/instaclustr/operator/apis/clusterresources/v1beta1"
-	"github.com/instaclustr/operator/pkg/instaclustr/mock"
+	"github.com/instaclustr/operator/pkg/instaclustr"
 	"github.com/instaclustr/operator/pkg/models"
 )
 
-var _ = Describe("Successful creation of a GCP VPC Peering resource", func() {
+var _ = Describe("Successful creation of a GCP VPC Peering resource", Ordered, func() {
+	gcpVPCPeeringSpec := v1beta1.GCPVPCPeeringSpec{
+		VPCPeeringSpec: v1beta1.VPCPeeringSpec{
+			DataCentreID: "375e4d1c-2f77-4d02-a6f2-1af617ff2ab2",
+			PeerSubnets:  []string{"172.31.0.0/16", "192.168.0.0/16"},
+		},
+		PeerProjectID:      "pid-132313",
+		PeerVPCNetworkName: "vpc-123123123",
+	}
+
+	ctx := context.Background()
+	resource := v1beta1.GCPVPCPeering{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gcpvpcpeering",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"instaclustr.com/test": "true",
+			},
+		},
+		Spec: gcpVPCPeeringSpec,
+	}
+
+	key := client.ObjectKeyFromObject(&resource)
+
 	Context("When setting up a GCP VPC Peering CRD", func() {
-		gcpVPCPeeringSpec := v1beta1.GCPVPCPeeringSpec{
-			VPCPeeringSpec: v1beta1.VPCPeeringSpec{
-				DataCentreID: "375e4d1c-2f77-4d02-a6f2-1af617ff2ab2",
-				PeerSubnets:  []string{"172.31.0.0/16", "192.168.0.0/16"},
-			},
-			PeerProjectID:      "pid-132313",
-			PeerVPCNetworkName: "vpc-123123123",
-		}
-
-		ctx := context.Background()
-		resource := v1beta1.GCPVPCPeering{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "gcpvpcpeering",
-				Namespace: "default",
-				Annotations: map[string]string{
-					models.ResourceStateAnnotation: models.CreatingEvent,
-				},
-			},
-			Spec: gcpVPCPeeringSpec,
-		}
-
 		It("Should create a GCP VPC Peering resources", func() {
 			Expect(k8sClient.Create(ctx, &resource)).Should(Succeed())
 
 			By("Sending GCP VPC Peering Specification to Instaclustr API v2")
-			var gcpVNetPeering v1beta1.GCPVPCPeering
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "gcpvpcpeering", Namespace: "default"}, &gcpVNetPeering); err != nil {
+				if err := k8sClient.Get(ctx, key, &resource); err != nil {
 					return false
 				}
 
-				return gcpVNetPeering.Status.ID == mock.StatusID
+				if !controllerutil.ContainsFinalizer(&resource, models.DeletionFinalizer) {
+					return false
+				}
+
+				return resource.Status.ID != ""
 			}).Should(BeTrue())
+		})
+	})
+
+	Context("When deleting GCPVPCPeering k8s resource", func() {
+		It("Should delete the resource in k8s and API", FlakeAttempts(3), func() {
+			id := resource.Status.ID
+
+			By("sending delete request to k8s")
+			Expect(k8sClient.Delete(ctx, &resource)).Should(Succeed())
+
+			By("checking if resource exists on the Instaclustr API")
+			Eventually(func() error {
+				_, err := instaClient.GetPeeringStatus(id, instaclustr.GCPPeeringEndpoint)
+				return err
+			}, timeout, interval).Should(Equal(instaclustr.NotFound))
+
+			By("checking if the resource exists in k8s")
+			Eventually(func() bool {
+				var resource v1beta1.GCPVPCPeering
+				return errors.IsNotFound(k8sClient.Get(ctx, key, &resource))
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 })

--- a/pkg/instaclustr/mock/server/go/api_aws_encryption_key_v2.go
+++ b/pkg/instaclustr/mock/server/go/api_aws_encryption_key_v2.go
@@ -52,27 +52,27 @@ func (c *AWSEncryptionKeyV2APIController) Routes() Routes {
 	return Routes{
 		"ClusterManagementV2DataSourcesProvidersAwsEncryptionKeysV2Get": Route{
 			strings.ToUpper("Get"),
-			"/cluster-management/v2/data-sources/providers/aws/encryption-keys/v2",
+			"/cluster-management/v2/data-sources/providers/aws/encryption-keys/v2/",
 			c.ClusterManagementV2DataSourcesProvidersAwsEncryptionKeysV2Get,
 		},
 		"ClusterManagementV2OperationsProvidersAwsEncryptionKeysV2EncryptionKeyIdValidateV2Get": Route{
 			strings.ToUpper("Get"),
-			"/cluster-management/v2/operations/providers/aws/encryption-keys/v2/{encryptionKeyId}/validate/v2",
+			"/cluster-management/v2/operations/providers/aws/encryption-keys/v2/{encryptionKeyId}/validate/v2/",
 			c.ClusterManagementV2OperationsProvidersAwsEncryptionKeysV2EncryptionKeyIdValidateV2Get,
 		},
 		"ClusterManagementV2ResourcesProvidersAwsEncryptionKeysV2EncryptionKeyIdDelete": Route{
 			strings.ToUpper("Delete"),
-			"/cluster-management/v2/resources/providers/aws/encryption-keys/v2/{encryptionKeyId}",
+			"/cluster-management/v2/resources/providers/aws/encryption-keys/v2/{encryptionKeyId}/",
 			c.ClusterManagementV2ResourcesProvidersAwsEncryptionKeysV2EncryptionKeyIdDelete,
 		},
 		"ClusterManagementV2ResourcesProvidersAwsEncryptionKeysV2EncryptionKeyIdGet": Route{
 			strings.ToUpper("Get"),
-			"/cluster-management/v2/resources/providers/aws/encryption-keys/v2/{encryptionKeyId}",
+			"/cluster-management/v2/resources/providers/aws/encryption-keys/v2/{encryptionKeyId}/",
 			c.ClusterManagementV2ResourcesProvidersAwsEncryptionKeysV2EncryptionKeyIdGet,
 		},
 		"ClusterManagementV2ResourcesProvidersAwsEncryptionKeysV2Post": Route{
 			strings.ToUpper("Post"),
-			"/cluster-management/v2/resources/providers/aws/encryption-keys/v2",
+			"/cluster-management/v2/resources/providers/aws/encryption-keys/v2/",
 			c.ClusterManagementV2ResourcesProvidersAwsEncryptionKeysV2Post,
 		},
 	}

--- a/pkg/instaclustr/mock/server/go/api_aws_endpoint_service_principals_v2.go
+++ b/pkg/instaclustr/mock/server/go/api_aws_endpoint_service_principals_v2.go
@@ -62,12 +62,12 @@ func (c *AWSEndpointServicePrincipalsV2APIController) Routes() Routes {
 		},
 		"ClusterManagementV2ResourcesAwsEndpointServicePrincipalsV2PrincipalIdDelete": Route{
 			strings.ToUpper("Delete"),
-			"/cluster-management/v2/resources/aws-endpoint-service-principals/v2/{principalId}",
+			"/cluster-management/v2/resources/aws-endpoint-service-principals/v2/{principalId}/",
 			c.ClusterManagementV2ResourcesAwsEndpointServicePrincipalsV2PrincipalIdDelete,
 		},
 		"ClusterManagementV2ResourcesAwsEndpointServicePrincipalsV2PrincipalIdGet": Route{
 			strings.ToUpper("Get"),
-			"/cluster-management/v2/resources/aws-endpoint-service-principals/v2/{principalId}",
+			"/cluster-management/v2/resources/aws-endpoint-service-principals/v2/{principalId}/",
 			c.ClusterManagementV2ResourcesAwsEndpointServicePrincipalsV2PrincipalIdGet,
 		},
 	}

--- a/pkg/instaclustr/mock/server/go/api_aws_security_group_firewall_rule_v2.go
+++ b/pkg/instaclustr/mock/server/go/api_aws_security_group_firewall_rule_v2.go
@@ -52,22 +52,22 @@ func (c *AWSSecurityGroupFirewallRuleV2APIController) Routes() Routes {
 	return Routes{
 		"ClusterManagementV2DataSourcesProvidersAwsAwsClusterClusterIdSecurityGroupFirewallRulesV2Get": Route{
 			strings.ToUpper("Get"),
-			"/cluster-management/v2/data-sources/providers/aws/aws_cluster/{clusterId}/security-group-firewall-rules/v2",
+			"/cluster-management/v2/data-sources/providers/aws/aws_cluster/{clusterId}/security-group-firewall-rules/v2/",
 			c.ClusterManagementV2DataSourcesProvidersAwsAwsClusterClusterIdSecurityGroupFirewallRulesV2Get,
 		},
 		"ClusterManagementV2ResourcesProvidersAwsSecurityGroupFirewallRulesV2FirewallRuleIdDelete": Route{
 			strings.ToUpper("Delete"),
-			"/cluster-management/v2/resources/providers/aws/security-group-firewall-rules/v2/{firewallRuleId}",
+			"/cluster-management/v2/resources/providers/aws/security-group-firewall-rules/v2/{firewallRuleId}/",
 			c.ClusterManagementV2ResourcesProvidersAwsSecurityGroupFirewallRulesV2FirewallRuleIdDelete,
 		},
 		"ClusterManagementV2ResourcesProvidersAwsSecurityGroupFirewallRulesV2FirewallRuleIdGet": Route{
 			strings.ToUpper("Get"),
-			"/cluster-management/v2/resources/providers/aws/security-group-firewall-rules/v2/{firewallRuleId}",
+			"/cluster-management/v2/resources/providers/aws/security-group-firewall-rules/v2/{firewallRuleId}/",
 			c.ClusterManagementV2ResourcesProvidersAwsSecurityGroupFirewallRulesV2FirewallRuleIdGet,
 		},
 		"ClusterManagementV2ResourcesProvidersAwsSecurityGroupFirewallRulesV2Post": Route{
 			strings.ToUpper("Post"),
-			"/cluster-management/v2/resources/providers/aws/security-group-firewall-rules/v2",
+			"/cluster-management/v2/resources/providers/aws/security-group-firewall-rules/v2/",
 			c.ClusterManagementV2ResourcesProvidersAwsSecurityGroupFirewallRulesV2Post,
 		},
 	}

--- a/pkg/instaclustr/mock/server/go/api_awsvpc_peer_v2.go
+++ b/pkg/instaclustr/mock/server/go/api_awsvpc_peer_v2.go
@@ -52,27 +52,27 @@ func (c *AWSVPCPeerV2APIController) Routes() Routes {
 	return Routes{
 		"ClusterManagementV2DataSourcesProvidersAwsVpcPeersV2Get": Route{
 			strings.ToUpper("Get"),
-			"/cluster-management/v2/data-sources/providers/aws/vpc-peers/v2",
+			"/cluster-management/v2/data-sources/providers/aws/vpc-peers/v2/",
 			c.ClusterManagementV2DataSourcesProvidersAwsVpcPeersV2Get,
 		},
 		"ClusterManagementV2ResourcesProvidersAwsVpcPeersV2Post": Route{
 			strings.ToUpper("Post"),
-			"/cluster-management/v2/resources/providers/aws/vpc-peers/v2",
+			"/cluster-management/v2/resources/providers/aws/vpc-peers/v2/",
 			c.ClusterManagementV2ResourcesProvidersAwsVpcPeersV2Post,
 		},
 		"ClusterManagementV2ResourcesProvidersAwsVpcPeersV2VpcPeerIdDelete": Route{
 			strings.ToUpper("Delete"),
-			"/cluster-management/v2/resources/providers/aws/vpc-peers/v2/{vpcPeerId}",
+			"/cluster-management/v2/resources/providers/aws/vpc-peers/v2/{vpcPeerId}/",
 			c.ClusterManagementV2ResourcesProvidersAwsVpcPeersV2VpcPeerIdDelete,
 		},
 		"ClusterManagementV2ResourcesProvidersAwsVpcPeersV2VpcPeerIdGet": Route{
 			strings.ToUpper("Get"),
-			"/cluster-management/v2/resources/providers/aws/vpc-peers/v2/{vpcPeerId}",
+			"/cluster-management/v2/resources/providers/aws/vpc-peers/v2/{vpcPeerId}/",
 			c.ClusterManagementV2ResourcesProvidersAwsVpcPeersV2VpcPeerIdGet,
 		},
 		"ClusterManagementV2ResourcesProvidersAwsVpcPeersV2VpcPeerIdPut": Route{
 			strings.ToUpper("Put"),
-			"/cluster-management/v2/resources/providers/aws/vpc-peers/v2/{vpcPeerId}",
+			"/cluster-management/v2/resources/providers/aws/vpc-peers/v2/{vpcPeerId}/",
 			c.ClusterManagementV2ResourcesProvidersAwsVpcPeersV2VpcPeerIdPut,
 		},
 	}

--- a/pkg/instaclustr/mock/server/go/api_awsvpc_peer_v2_service.go
+++ b/pkg/instaclustr/mock/server/go/api_awsvpc_peer_v2_service.go
@@ -13,17 +13,22 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync"
+
+	"github.com/google/uuid"
 )
 
 // AWSVPCPeerV2APIService is a service that implements the logic for the AWSVPCPeerV2APIServicer
 // This service should implement the business logic for every endpoint for the AWSVPCPeerV2API API.
 // Include any external packages or services that will be required by this service.
 type AWSVPCPeerV2APIService struct {
+	mu    sync.RWMutex
+	peers map[string]*AwsVpcPeerV2
 }
 
 // NewAWSVPCPeerV2APIService creates a default api service
 func NewAWSVPCPeerV2APIService() AWSVPCPeerV2APIServicer {
-	return &AWSVPCPeerV2APIService{}
+	return &AWSVPCPeerV2APIService{peers: map[string]*AwsVpcPeerV2{}}
 }
 
 // ClusterManagementV2DataSourcesProvidersAwsVpcPeersV2Get - List all AWS VPC Peering requests
@@ -45,7 +50,19 @@ func (s *AWSVPCPeerV2APIService) ClusterManagementV2ResourcesProvidersAwsVpcPeer
 	// TODO: Uncomment the next line to return response Response(202, AwsVpcPeerV2{}) or use other options such as http.Ok ...
 	// return Response(202, AwsVpcPeerV2{}), nil
 
-	return Response(http.StatusNotImplemented, nil), errors.New("ClusterManagementV2ResourcesProvidersAwsVpcPeersV2Post method not implemented")
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id, err := uuid.NewUUID()
+	if err != nil {
+		return Response(http.StatusInternalServerError, nil), err
+	}
+
+	awsVpcPeerV2.Id = id.String()
+
+	s.peers[awsVpcPeerV2.Id] = &awsVpcPeerV2
+
+	return Response(http.StatusAccepted, &awsVpcPeerV2), nil
 }
 
 // ClusterManagementV2ResourcesProvidersAwsVpcPeersV2VpcPeerIdDelete - Delete AWS VPC Peering Connection
@@ -59,7 +76,17 @@ func (s *AWSVPCPeerV2APIService) ClusterManagementV2ResourcesProvidersAwsVpcPeer
 	// TODO: Uncomment the next line to return response Response(404, ErrorListResponseV2{}) or use other options such as http.Ok ...
 	// return Response(404, ErrorListResponseV2{}), nil
 
-	return Response(http.StatusNotImplemented, nil), errors.New("ClusterManagementV2ResourcesProvidersAwsVpcPeersV2VpcPeerIdDelete method not implemented")
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, exists := s.peers[vpcPeerId]
+	if !exists {
+		return Response(http.StatusNotFound, nil), nil
+	}
+
+	delete(s.peers, vpcPeerId)
+
+	return Response(http.StatusNoContent, nil), nil
 }
 
 // ClusterManagementV2ResourcesProvidersAwsVpcPeersV2VpcPeerIdGet - Get AWS VPC Peering Connection info
@@ -73,7 +100,15 @@ func (s *AWSVPCPeerV2APIService) ClusterManagementV2ResourcesProvidersAwsVpcPeer
 	// TODO: Uncomment the next line to return response Response(404, ErrorListResponseV2{}) or use other options such as http.Ok ...
 	// return Response(404, ErrorListResponseV2{}), nil
 
-	return Response(http.StatusNotImplemented, nil), errors.New("ClusterManagementV2ResourcesProvidersAwsVpcPeersV2VpcPeerIdGet method not implemented")
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	peer, exists := s.peers[vpcPeerId]
+	if !exists {
+		return Response(http.StatusNotFound, nil), nil
+	}
+
+	return Response(http.StatusOK, peer), nil
 }
 
 // ClusterManagementV2ResourcesProvidersAwsVpcPeersV2VpcPeerIdPut - Update AWS VPC Peering Connection info


### PR DESCRIPTION
This PR adds integrations for all resources of `clusterresources` group.

It adds creation test cases for the following resources:
* `AWSEncryptionKey`
* `AWSEndpointServicePrincipal`

It adds deletion test cases for the following resources:
* `AWSEncrpytionKey`
* `AWSEndpointServicePrincipal`
*  `AWSSecurityGroupFirewallRule`
* `AWSVPCPerring`
* `AzureVNetPeering`
* `ClusterNetworkFirewallRule`