### PR TITLE
External changes messages enhancement

### DIFF
--- a/controllers/clusterresources/cassandrauser_controller.go
+++ b/controllers/clusterresources/cassandrauser_controller.go
@@ -31,10 +31,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/instaclustr/operator/apis/clusterresources/v1beta1"
-	"github.com/instaclustr/operator/pkg/helpers/utils"
 	"github.com/instaclustr/operator/pkg/instaclustr"
 	"github.com/instaclustr/operator/pkg/models"
 	"github.com/instaclustr/operator/pkg/ratelimiter"
+	"github.com/instaclustr/operator/pkg/utils"
 )
 
 // CassandraUserReconciler reconciles a CassandraUser object

--- a/controllers/clusterresources/opensearchuser_controller.go
+++ b/controllers/clusterresources/opensearchuser_controller.go
@@ -33,10 +33,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	clusterresourcesv1beta1 "github.com/instaclustr/operator/apis/clusterresources/v1beta1"
-	"github.com/instaclustr/operator/pkg/helpers/utils"
 	"github.com/instaclustr/operator/pkg/instaclustr"
 	"github.com/instaclustr/operator/pkg/models"
 	"github.com/instaclustr/operator/pkg/ratelimiter"
+	"github.com/instaclustr/operator/pkg/utils"
 )
 
 // OpenSearchUserReconciler reconciles a OpenSearchUser object

--- a/controllers/clusterresources/postgresqluser_controller.go
+++ b/controllers/clusterresources/postgresqluser_controller.go
@@ -35,10 +35,10 @@ import (
 
 	clusterresourcesv1beta1 "github.com/instaclustr/operator/apis/clusterresources/v1beta1"
 	"github.com/instaclustr/operator/pkg/exposeservice"
-	"github.com/instaclustr/operator/pkg/helpers/utils"
 	"github.com/instaclustr/operator/pkg/instaclustr"
 	"github.com/instaclustr/operator/pkg/models"
 	"github.com/instaclustr/operator/pkg/ratelimiter"
+	"github.com/instaclustr/operator/pkg/utils"
 )
 
 // PostgreSQLUserReconciler reconciles a PostgreSQLUser object

--- a/controllers/clusterresources/redisuser_controller.go
+++ b/controllers/clusterresources/redisuser_controller.go
@@ -34,10 +34,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/instaclustr/operator/apis/clusterresources/v1beta1"
-	"github.com/instaclustr/operator/pkg/helpers/utils"
 	"github.com/instaclustr/operator/pkg/instaclustr"
 	"github.com/instaclustr/operator/pkg/models"
 	"github.com/instaclustr/operator/pkg/ratelimiter"
+	"github.com/instaclustr/operator/pkg/utils"
 )
 
 // RedisUserReconciler reconciles a RedisUser object

--- a/controllers/kafkamanagement/usercertificate_controller.go
+++ b/controllers/kafkamanagement/usercertificate_controller.go
@@ -41,10 +41,10 @@ import (
 	clustersv1beta1 "github.com/instaclustr/operator/apis/clusters/v1beta1"
 	kafkamanagementv1beta1 "github.com/instaclustr/operator/apis/kafkamanagement/v1beta1"
 	"github.com/instaclustr/operator/pkg/apiextensions"
-	"github.com/instaclustr/operator/pkg/helpers/utils"
 	"github.com/instaclustr/operator/pkg/instaclustr"
 	"github.com/instaclustr/operator/pkg/models"
 	"github.com/instaclustr/operator/pkg/ratelimiter"
+	"github.com/instaclustr/operator/pkg/utils"
 )
 
 // UserCertificateReconciler reconciles a CertificateSigningRequest object

--- a/pkg/models/operator.go
+++ b/pkg/models/operator.go
@@ -181,3 +181,8 @@ const (
 	CSRSecretKey               = "csr"
 	PrivateKeySecretKey        = "privateKey"
 )
+
+const (
+	ExternalChangesBaseMessage = "There are external changes on the Instaclustr console. Please reconcile the specification manually."
+	SpecPath                   = "path"
+)

--- a/pkg/utils/dcomparison/map_diff.go
+++ b/pkg/utils/dcomparison/map_diff.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package dcomparison provides a solution for deeply comparing two maps,
+// including their nested maps and slices. It is designed to identify differences
+// between two maps that can contain a variety of data types, such as strings,
+// integers, other maps, and slices.
+package dcomparison
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// ObjectDiff stores the path to a value and the differing values from two maps.
+type ObjectDiff struct {
+	Field  string
+	Value1 any
+	Value2 any
+}
+
+// ObjectDiffs is a slice of ObjectDiff
+type ObjectDiffs []ObjectDiff
+
+func (o *ObjectDiffs) Append(diff ObjectDiff) {
+	*o = append(*o, diff)
+}
+
+// compare recursively compares values and populates diffs.
+func compare(path string, value1, value2 any, diffs *ObjectDiffs) {
+	if reflect.DeepEqual(value1, value2) {
+		return
+	}
+
+	v1Type := reflect.TypeOf(value1)
+	v2Type := reflect.TypeOf(value2)
+
+	if v1Type == v2Type && v1Type != nil {
+		switch v1Type.Kind() {
+		case reflect.Map:
+			map1 := reflect.ValueOf(value1)
+			map2 := reflect.ValueOf(value2)
+
+			for _, key := range map1.MapKeys() {
+				currentField := fmt.Sprintf("%s.%v", path, key)
+
+				map1Value := map1.MapIndex(key)
+				map2Value := map2.MapIndex(key)
+				if map2Value.IsValid() {
+					compare(currentField, map1Value.Interface(), map2Value.Interface(), diffs)
+				} else {
+					diffs.Append(ObjectDiff{
+						Field:  currentField,
+						Value1: map1Value.Interface(),
+						Value2: nil,
+					})
+				}
+			}
+
+			for _, key := range map2.MapKeys() {
+				if !map1.MapIndex(key).IsValid() {
+					subPath := fmt.Sprintf("%s.%v", path, key)
+					diffs.Append(ObjectDiff{
+						Field:  subPath,
+						Value1: nil,
+						Value2: map2.MapIndex(key).Interface(),
+					})
+				}
+			}
+		case reflect.Slice:
+			slice1 := reflect.ValueOf(value1)
+			slice2 := reflect.ValueOf(value2)
+			maxLength := max(slice1.Len(), slice2.Len())
+
+			for i := 0; i < maxLength; i++ {
+				elem1, elem2 := getSliceElement(slice1, i), getSliceElement(slice2, i)
+				subPath := fmt.Sprintf("%s[%d]", path, i)
+				compare(subPath, elem1, elem2, diffs)
+			}
+		default:
+			diffs.Append(ObjectDiff{
+				Field:  path,
+				Value1: value1,
+				Value2: value2,
+			})
+		}
+	} else {
+		diffs.Append(ObjectDiff{
+			Field:  path,
+			Value1: value1,
+			Value2: value2,
+		})
+	}
+}
+
+// getSliceElement safely gets the element at index i from a reflect.Value of a slice.
+func getSliceElement(slice reflect.Value, i int) any {
+	if i < slice.Len() {
+		return slice.Index(i).Interface()
+	}
+	return nil
+}
+
+// max returns the maximum of two integers.
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// MapsDiff compares two maps and returns a slice of ObjectDiff with the differences.
+func MapsDiff(path string, map1, map2 map[string]any) ObjectDiffs {
+	var diffs ObjectDiffs
+	compare(path, map1, map2, &diffs)
+	return diffs
+}

--- a/pkg/utils/dcomparison/map_diff_test.go
+++ b/pkg/utils/dcomparison/map_diff_test.go
@@ -1,0 +1,290 @@
+package dcomparison_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/instaclustr/operator/pkg/utils/dcomparison"
+)
+
+func TestCompareMaps(t *testing.T) {
+	t.Parallel()
+
+	type _t struct {
+		map1     map[string]any
+		map2     map[string]any
+		expected dcomparison.ObjectDiffs
+	}
+
+	cases := map[string]_t{
+		"both maps are nil": {},
+		"map2 is nil": {
+			map1: map[string]any{
+				"field1": "value1",
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.field1", Value1: "value1"},
+			},
+		},
+		"map1 is nil": {
+			map2: map[string]any{
+				"field1": "value1",
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.field1", Value2: "value1"},
+			},
+		},
+		"maps do not contain nested maps and they are equal": {
+			map1: map[string]any{
+				"field1": "value1",
+			},
+			map2: map[string]any{
+				"field1": "value1",
+			},
+		},
+		"maps do not contain nested maps and they are not equal": {
+			map1: map[string]any{
+				"field1": "value1",
+			},
+			map2: map[string]any{
+				"field1": "value2",
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.field1", Value1: "value1", Value2: "value2"},
+			},
+		},
+		"maps contain nested maps and they are equal": {
+			map1: map[string]any{
+				"nestedMap": map[string]any{
+					"field1": "value1",
+				},
+			},
+			map2: map[string]any{
+				"nestedMap": map[string]any{
+					"field1": "value1",
+				},
+			},
+		},
+		"maps contain nested maps and they are not equal": {
+			map1: map[string]any{
+				"nestedMap": map[string]any{
+					"field1": "value1",
+				},
+			},
+			map2: map[string]any{
+				"nestedMap": map[string]any{
+					"field1": "value2",
+				},
+			},
+			expected: []dcomparison.ObjectDiff{
+				{Field: "spec.nestedMap.field1", Value1: "value1", Value2: "value2"},
+			},
+		},
+		"maps contain slices and they are equal": {
+			map1: map[string]any{
+				"slice": []int{1, 2, 3},
+			},
+			map2: map[string]any{
+				"slice": []int{1, 2, 3},
+			},
+		},
+		"maps contain slices and they are not equal": {
+			map1: map[string]any{
+				"slice": []int{1, 2, 3},
+			},
+			map2: map[string]any{
+				"slice": []int{1, 2},
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.slice[2]", Value1: 3},
+			},
+		},
+		"maps contain slices of nested maps and they are equal": {
+			map1: map[string]any{
+				"slice": []map[string]any{
+					{
+						"field1": "value1",
+						"field2": "value2",
+					},
+				},
+			},
+			map2: map[string]any{
+				"slice": []map[string]any{
+					{
+						"field1": "value1",
+						"field2": "value2",
+					},
+				},
+			},
+		},
+		"maps contain slices of nested maps and they are not equal": {
+			map1: map[string]any{
+				"slice": []map[string]any{
+					{
+						"field1": "value1",
+						"field2": "value2",
+					},
+				},
+			},
+			map2: map[string]any{
+				"slice": []map[string]any{
+					{
+						"field1": "value1",
+						"field2": "value1",
+					},
+				},
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.slice[0].field2", Value1: "value2", Value2: "value1"},
+			},
+		},
+		"maps contain fields with different types": {
+			map1: map[string]any{
+				"field1": "1",
+			},
+			map2: map[string]any{
+				"field1": 1,
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.field1", Value1: "1", Value2: 1},
+			},
+		},
+		"the first map contains slice with length bigger than the second contains": {
+			map1: map[string]any{
+				"slice": []int{1, 2, 3, 4},
+			},
+			map2: map[string]any{
+				"slice": []int{1, 2, 3},
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.slice[3]", Value1: 4, Value2: nil},
+			},
+		},
+		"the second map contains slice with length bigger than the first contains": {
+			map1: map[string]any{
+				"slice": []int{1, 2, 3},
+			},
+			map2: map[string]any{
+				"slice": []int{1, 2, 3, 4},
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.slice[3]", Value1: nil, Value2: 4},
+			},
+		},
+		"the first map contains slice with length bigger than the second contains by two elements": {
+			map1: map[string]any{
+				"slice": []int{1, 2, 3, 4, 5},
+			},
+			map2: map[string]any{
+				"slice": []int{1, 2, 3},
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.slice[3]", Value1: 4, Value2: nil},
+				{Field: "spec.slice[4]", Value1: 5, Value2: nil},
+			},
+		},
+		"the second map contains slice with length bigger than the first contains by two elements": {
+			map1: map[string]any{
+				"slice": []int{1, 2, 3},
+			},
+			map2: map[string]any{
+				"slice": []int{1, 2, 3, 4, 5},
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.slice[3]", Value1: nil, Value2: 4},
+				{Field: "spec.slice[4]", Value1: nil, Value2: 5},
+			},
+		},
+		"the first map contains nested map with length bigger than the second contains": {
+			map1: map[string]any{
+				"slice": map[string]any{
+					"field1": "value1",
+					"field2": "value2",
+					"field3": "value3",
+				},
+			},
+			map2: map[string]any{
+				"slice": map[string]any{
+					"field1": "value1",
+					"field2": "value2",
+				},
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.slice.field3", Value1: "value3", Value2: nil},
+			},
+		},
+		"the second map contains nested map with length bigger than the first contains": {
+			map1: map[string]any{
+				"slice": map[string]any{
+					"field1": "value1",
+					"field2": "value2",
+				},
+			},
+			map2: map[string]any{
+				"slice": map[string]any{
+					"field1": "value1",
+					"field2": "value2",
+					"field3": "value3",
+				},
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.slice.field3", Value1: nil, Value2: "value3"},
+			},
+		},
+		"the first map contains nested map with length bigger than the second contains by two elements": {
+			map1: map[string]any{
+				"slice": map[string]any{
+					"field1": "value1",
+					"field2": "value2",
+					"field3": "value3",
+					"field4": "value4",
+				},
+			},
+			map2: map[string]any{
+				"slice": map[string]any{
+					"field1": "value1",
+					"field2": "value2",
+				},
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.slice.field3", Value1: "value3", Value2: nil},
+				{Field: "spec.slice.field4", Value1: "value4", Value2: nil},
+			},
+		},
+		"the second map contains nested map with length bigger than the first contains by two elements": {
+			map1: map[string]any{
+				"slice": map[string]any{
+					"field1": "value1",
+					"field2": "value2",
+				},
+			},
+			map2: map[string]any{
+				"slice": map[string]any{
+					"field1": "value1",
+					"field2": "value2",
+					"field3": "value3",
+					"field4": "value4",
+				},
+			},
+			expected: dcomparison.ObjectDiffs{
+				{Field: "spec.slice.field3", Value1: nil, Value2: "value3"},
+				{Field: "spec.slice.field4", Value1: nil, Value2: "value4"},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			_ = name
+			got := dcomparison.MapsDiff("spec", c.map1, c.map2)
+
+			if !reflect.DeepEqual(got, c.expected) {
+				gotJSON, _ := json.MarshalIndent(got, " ", " ")
+				expectedJSON, _ := json.MarshalIndent(got, " ", " ")
+				t.Errorf("expected: %s, got: %s", gotJSON, expectedJSON)
+			}
+		})
+	}
+}

--- a/pkg/utils/user_creds_from_secret.go
+++ b/pkg/utils/user_creds_from_secret.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (


### PR DESCRIPTION
## Problem

The current implementation of indicating if there are any external changes to the resource spec writes to events the whole k8s and Instaclustr resource specs. It causes problems in identifying which exact field of the k8s resource differs from the value from the Instaclustr spec.

## Solution

This PR adds `dcomprasion` pkg that provides a deep comparing function. It returns a slice of `ObjectDiff`. Each `ObjectDiff` stores the field, the value of the field from the first object, and the value from the second.