### PR TITLE
PostgreSQL validation webhook fix

### DIFF
--- a/apis/clusters/v1beta1/postgresql_types.go
+++ b/apis/clusters/v1beta1/postgresql_types.go
@@ -453,12 +453,12 @@ func (pgs *PgSpec) validateImmutableDCsFieldsUpdate(oldSpec PgSpec) error {
 
 		err = newDC.validateIntraDCImmutableFields(oldDC.IntraDataCentreReplication)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		err = newDC.validateInterDCImmutableFields(oldDC.InterDataCentreReplication)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		if newDC.NodesNumber != oldDC.NodesNumber {


### PR DESCRIPTION
Validation of changes for `DataCentreReplication` and `interDataCentreReplication` fields has been enabled.

closes #662