### PR TITLE
Issue-654, Prohibiting cluster spec updating until they are running

### DIFF
--- a/apis/clusters/v1beta1/cadence_webhook.go
+++ b/apis/clusters/v1beta1/cadence_webhook.go
@@ -243,6 +243,10 @@ func (cv *cadenceValidator) ValidateUpdate(ctx context.Context, old runtime.Obje
 		return models.ErrTypeAssertion
 	}
 
+	if c.Status.ID == "" {
+		return cv.ValidateCreate(ctx, c)
+	}
+
 	err := c.Spec.validateUpdate(oldCluster.Spec)
 	if err != nil {
 		return fmt.Errorf("cannot update immutable fields: %v", err)
@@ -253,6 +257,11 @@ func (cv *cadenceValidator) ValidateUpdate(ctx context.Context, old runtime.Obje
 		if err != nil {
 			return err
 		}
+	}
+
+	// ensuring if the cluster is ready for the spec updating
+	if (c.Status.CurrentClusterOperationStatus != models.NoOperation || c.Status.State != models.RunningStatus) && c.Generation != oldCluster.Generation {
+		return models.ErrClusterIsNotReadyToUpdate
 	}
 
 	return nil

--- a/apis/clusters/v1beta1/kafkaconnect_webhook.go
+++ b/apis/clusters/v1beta1/kafkaconnect_webhook.go
@@ -209,6 +209,11 @@ func (kcv *kafkaConnectValidator) ValidateUpdate(ctx context.Context, old runtim
 		return fmt.Errorf("cannot update immutable fields: %v", err)
 	}
 
+	// ensuring if the cluster is ready for the spec updating
+	if (kc.Status.CurrentClusterOperationStatus != models.NoOperation || kc.Status.State != models.RunningStatus) && kc.Generation != oldCluster.Generation {
+		return models.ErrClusterIsNotReadyToUpdate
+	}
+
 	return nil
 }
 

--- a/apis/clusters/v1beta1/opensearch_webhook.go
+++ b/apis/clusters/v1beta1/opensearch_webhook.go
@@ -233,6 +233,11 @@ func (osv *openSearchValidator) ValidateUpdate(ctx context.Context, old runtime.
 		return err
 	}
 
+	// ensuring if the cluster is ready for the spec updating
+	if (os.Status.CurrentClusterOperationStatus != models.NoOperation || os.Status.State != models.RunningStatus) && os.Generation != oldCluster.Generation {
+		return models.ErrClusterIsNotReadyToUpdate
+	}
+
 	return nil
 }
 

--- a/apis/clusters/v1beta1/postgresql_webhook.go
+++ b/apis/clusters/v1beta1/postgresql_webhook.go
@@ -225,6 +225,11 @@ func (pgv *pgValidator) ValidateUpdate(ctx context.Context, old runtime.Object, 
 		}
 	}
 
+	// ensuring if the cluster is ready for the spec updating
+	if (pg.Status.CurrentClusterOperationStatus != models.NoOperation || pg.Status.State != models.RunningStatus) && pg.Generation != oldCluster.Generation {
+		return models.ErrClusterIsNotReadyToUpdate
+	}
+
 	return nil
 }
 

--- a/apis/clusters/v1beta1/zookeeper_webhook.go
+++ b/apis/clusters/v1beta1/zookeeper_webhook.go
@@ -123,11 +123,6 @@ func (zv *zookeeperValidator) ValidateUpdate(ctx context.Context, old runtime.Ob
 		return zv.ValidateCreate(ctx, z)
 	}
 
-	// skip validation when we receive cluster specification update from the Instaclustr Console.
-	if z.Annotations[models.ExternalChangesAnnotation] == models.True {
-		return nil
-	}
-
 	return nil
 }
 

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -74,4 +74,5 @@ var (
 	ErrCreateClusterWithMultiDC                   = errors.New("multiple data center is still not supported. Please create a cluster with one data centre and add a second one when the cluster is in the running state")
 	ErrOnPremicesWithMultiDC                      = errors.New("on-premises cluster can be provisioned with only one data centre")
 	ErrUnsupportedDeletingDC                      = errors.New("deleting data centre is not supported")
+	ErrClusterIsNotReadyToUpdate                  = errors.New("cluster is not ready to update")
 )


### PR DESCRIPTION
The PR adds validation to the update webhooks to prevent cluster spec updating until their state is `running` or there is no cluster operation.

Also, it cleans up the codebase and adds some minor fixes.

closes #654