### PR TITLE
PrivateLink validation for Redis and Opensearch cluster resources

### DIFF
--- a/apis/clusters/v1beta1/opensearch_webhook.go
+++ b/apis/clusters/v1beta1/opensearch_webhook.go
@@ -125,6 +125,11 @@ func (osv *openSearchValidator) ValidateCreate(ctx context.Context, obj runtime.
 		if err != nil {
 			return err
 		}
+
+		err = dc.ValidatePrivateLink()
+		if err != nil {
+			return err
+		}
 	}
 
 	appVersions, err := osv.API.ListAppVersions(models.OpenSearchAppKind)
@@ -413,6 +418,14 @@ func validateDataNode(newNodes, oldNodes []*OpenSearchDataNodes) error {
 		if oldNodes[i].NodesNumber > newNodes[i].NodesNumber {
 			return fmt.Errorf("deleting nodes is not supported. Number of nodes must be greater than: %v", oldNodes[i].NodesNumber)
 		}
+	}
+
+	return nil
+}
+
+func (dc *OpenSearchDataCentre) ValidatePrivateLink() error {
+	if dc.CloudProvider != models.AWSVPC && dc.PrivateLink {
+		return models.ErrPrivateLinkSupportedOnlyForAWS
 	}
 
 	return nil

--- a/apis/clusters/v1beta1/redis_webhook.go
+++ b/apis/clusters/v1beta1/redis_webhook.go
@@ -143,7 +143,7 @@ func (rv *redisValidator) ValidateCreate(ctx context.Context, obj runtime.Object
 				return err
 			}
 		} else {
-			err := dc.DataCentre.ValidateCreation()
+			err := dc.ValidateCreate()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR provides validation of private link to prohibit creation of the Redis and Opensearch cluster resources with non-aws cloud provider.