### PR TITLE
Redis replicationFactor/replicaNodes immutable

### DIFF
--- a/apis/clusters/v1beta1/redis_types.go
+++ b/apis/clusters/v1beta1/redis_types.go
@@ -31,11 +31,14 @@ import (
 )
 
 type RedisDataCentre struct {
-	DataCentre  `json:",inline"`
+	DataCentre `json:",inline"`
+
 	MasterNodes int `json:"masterNodes"`
 
 	//+kubebuilder:validation:Minimum:=0
 	//+kubebuilder:validation:Maximum:=5
+	// ReplicationFactor defines how many replica nodes (aka nodesNumber) should be created for each master node
+	// (e.a. if there are 3 masterNodes and replicationFactor 1 then it creates 1 replicaNode for each accordingly).
 	ReplicationFactor int `json:"replicationFactor,omitempty"`
 
 	//+kubebuilder:validation:MaxItems:=1
@@ -303,7 +306,7 @@ func (rs *RedisStatus) DCsFromInstAPI(iDCs []*models.RedisDataCentre) (dcs []*Da
 	for _, iDC := range iDCs {
 		dc := rs.ClusterStatus.DCFromInstAPI(iDC.DataCentre)
 		dc.PrivateLink = privateLinkStatusesFromInstAPI(iDC.PrivateLink)
-
+		dc.NodesNumber += iDC.MasterNodes
 		dcs = append(dcs, dc)
 	}
 	return

--- a/apis/clusters/v1beta1/redis_webhook.go
+++ b/apis/clusters/v1beta1/redis_webhook.go
@@ -64,6 +64,14 @@ func (r *Redis) Default() {
 
 	for _, dataCentre := range r.Spec.DataCentres {
 		dataCentre.SetDefaultValues()
+
+		if dataCentre.MasterNodes != 0 {
+			if dataCentre.ReplicationFactor > 0 {
+				dataCentre.NodesNumber = dataCentre.MasterNodes * dataCentre.ReplicationFactor
+			} else {
+				dataCentre.ReplicationFactor = dataCentre.NodesNumber / dataCentre.MasterNodes
+			}
+		}
 	}
 }
 
@@ -234,6 +242,7 @@ type specificRedisFields struct {
 
 type immutableRedisDCFields struct {
 	immutableDC
+	ReplicationFactor int
 }
 
 func (rs *RedisSpec) ValidateUpdate(oldSpec RedisSpec) error {
@@ -332,6 +341,7 @@ func (rdc *RedisDataCentre) newImmutableFields() *immutableRedisDCFields {
 			ProviderAccountName: rdc.ProviderAccountName,
 			Network:             rdc.Network,
 		},
+		ReplicationFactor: rdc.ReplicationFactor,
 	}
 }
 

--- a/apis/clusters/v1beta1/structs.go
+++ b/apis/clusters/v1beta1/structs.go
@@ -48,7 +48,7 @@ type DataCentreStatus struct {
 	ID               string              `json:"id,omitempty"`
 	Status           string              `json:"status,omitempty"`
 	Nodes            []*Node             `json:"nodes,omitempty"`
-	NodeNumber       int                 `json:"nodeNumber,omitempty"`
+	NodesNumber      int                 `json:"nodesNumber,omitempty"`
 	EncryptionKeyID  string              `json:"encryptionKeyId,omitempty"`
 	PrivateLink      PrivateLinkStatuses `json:"privateLink,omitempty"`
 	ResizeOperations []*ResizeOperation  `json:"resizeOperations,omitempty"`
@@ -569,11 +569,11 @@ func areClusteredMaintenanceEventStatusEqual(a, b *clusterresource.MaintenanceEv
 
 func (cs *ClusterStatus) DCFromInstAPI(iDC models.DataCentre) *DataCentreStatus {
 	return &DataCentreStatus{
-		Name:       iDC.Name,
-		ID:         iDC.ID,
-		Status:     iDC.Status,
-		Nodes:      cs.NodesFromInstAPI(iDC.Nodes),
-		NodeNumber: iDC.NumberOfNodes,
+		Name:        iDC.Name,
+		ID:          iDC.ID,
+		Status:      iDC.Status,
+		Nodes:       cs.NodesFromInstAPI(iDC.Nodes),
+		NodesNumber: iDC.NumberOfNodes,
 	}
 }
 

--- a/config/crd/bases/clusters.instaclustr.com_cadences.yaml
+++ b/config/crd/bases/clusters.instaclustr.com_cadences.yaml
@@ -357,8 +357,6 @@ spec:
                       type: string
                     name:
                       type: string
-                    nodeNumber:
-                      type: integer
                     nodes:
                       items:
                         properties:
@@ -380,6 +378,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    nodesNumber:
+                      type: integer
                     privateLink:
                       items:
                         properties:

--- a/config/crd/bases/clusters.instaclustr.com_cassandras.yaml
+++ b/config/crd/bases/clusters.instaclustr.com_cassandras.yaml
@@ -314,8 +314,6 @@ spec:
                       type: string
                     name:
                       type: string
-                    nodeNumber:
-                      type: integer
                     nodes:
                       items:
                         properties:
@@ -337,6 +335,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    nodesNumber:
+                      type: integer
                     privateLink:
                       items:
                         properties:

--- a/config/crd/bases/clusters.instaclustr.com_kafkaconnects.yaml
+++ b/config/crd/bases/clusters.instaclustr.com_kafkaconnects.yaml
@@ -323,8 +323,6 @@ spec:
                       type: string
                     name:
                       type: string
-                    nodeNumber:
-                      type: integer
                     nodes:
                       items:
                         properties:
@@ -346,6 +344,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    nodesNumber:
+                      type: integer
                     privateLink:
                       items:
                         properties:

--- a/config/crd/bases/clusters.instaclustr.com_kafkas.yaml
+++ b/config/crd/bases/clusters.instaclustr.com_kafkas.yaml
@@ -331,8 +331,6 @@ spec:
                       type: string
                     name:
                       type: string
-                    nodeNumber:
-                      type: integer
                     nodes:
                       items:
                         properties:
@@ -354,6 +352,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    nodesNumber:
+                      type: integer
                     privateLink:
                       items:
                         properties:

--- a/config/crd/bases/clusters.instaclustr.com_opensearches.yaml
+++ b/config/crd/bases/clusters.instaclustr.com_opensearches.yaml
@@ -293,8 +293,6 @@ spec:
                       type: string
                     name:
                       type: string
-                    nodeNumber:
-                      type: integer
                     nodes:
                       items:
                         properties:
@@ -316,6 +314,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    nodesNumber:
+                      type: integer
                     privateLink:
                       items:
                         properties:

--- a/config/crd/bases/clusters.instaclustr.com_postgresqls.yaml
+++ b/config/crd/bases/clusters.instaclustr.com_postgresqls.yaml
@@ -304,8 +304,6 @@ spec:
                       type: string
                     name:
                       type: string
-                    nodeNumber:
-                      type: integer
                     nodes:
                       items:
                         properties:
@@ -327,6 +325,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    nodesNumber:
+                      type: integer
                     privateLink:
                       items:
                         properties:

--- a/config/crd/bases/clusters.instaclustr.com_redis.yaml
+++ b/config/crd/bases/clusters.instaclustr.com_redis.yaml
@@ -93,6 +93,10 @@ spec:
                     region:
                       type: string
                     replicationFactor:
+                      description: ReplicationFactor defines how many replica nodes
+                        (aka nodesNumber) should be created for each master node (e.a.
+                        if there are 3 masterNodes and replicationFactor 1 then it
+                        creates 1 replicaNode for each accordingly).
                       maximum: 5
                       minimum: 0
                       type: integer
@@ -285,8 +289,6 @@ spec:
                       type: string
                     name:
                       type: string
-                    nodeNumber:
-                      type: integer
                     nodes:
                       items:
                         properties:
@@ -308,6 +310,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    nodesNumber:
+                      type: integer
                     privateLink:
                       items:
                         properties:

--- a/config/crd/bases/clusters.instaclustr.com_zookeepers.yaml
+++ b/config/crd/bases/clusters.instaclustr.com_zookeepers.yaml
@@ -150,8 +150,6 @@ spec:
                       type: string
                     name:
                       type: string
-                    nodeNumber:
-                      type: integer
                     nodes:
                       items:
                         properties:
@@ -173,6 +171,8 @@ spec:
                             type: string
                         type: object
                       type: array
+                    nodesNumber:
+                      type: integer
                     privateLink:
                       items:
                         properties:

--- a/controllers/clusters/helpers.go
+++ b/controllers/clusters/helpers.go
@@ -102,7 +102,7 @@ func areDataCentresEqual(a, b []*v1beta1.DataCentreStatus) bool {
 		}
 
 		if a[i].Status != b[i].Status ||
-			a[i].NodeNumber != b[i].NodeNumber ||
+			a[i].NodesNumber != b[i].NodesNumber ||
 			a[i].EncryptionKeyID != b[i].EncryptionKeyID {
 			return false
 		}

--- a/controllers/clusters/kafkaconnect_controller_test.go
+++ b/controllers/clusters/kafkaconnect_controller_test.go
@@ -18,8 +18,9 @@ package clusters
 
 import (
 	"context"
-	openapi "github.com/instaclustr/operator/pkg/instaclustr/mock/server/go"
 	"os"
+
+	openapi "github.com/instaclustr/operator/pkg/instaclustr/mock/server/go"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -103,7 +104,7 @@ var _ = Describe("Kafka Connect Controller", func() {
 					return false
 				}
 
-				return kafkaConnect.Status.DataCentres[0].NodeNumber == newKafkaConnectNodeNumbers
+				return kafkaConnect.Status.DataCentres[0].NodesNumber == newKafkaConnectNodeNumbers
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/pkg/models/operator.go
+++ b/pkg/models/operator.go
@@ -186,5 +186,5 @@ const (
 
 const (
 	ExternalChangesBaseMessage = "There are external changes on the Instaclustr console. Please reconcile the specification manually."
-	SpecPath                   = "path"
+	SpecPath                   = "spec"
 )


### PR DESCRIPTION
This PR provides immutability for the `replicationFactor` and `replicaNodes` fields of the Redis data centre.

Also, it provides automatical reconcile of external changes of the k8s resource spec equals to instaclustr resource spec.

closes #676