### PR TITLE
External changes on several failed updates

### DIFF
--- a/controllers/clusters/cassandra_controller.go
+++ b/controllers/clusters/cassandra_controller.go
@@ -522,7 +522,7 @@ func (r *CassandraReconciler) handleUpdateCluster(
 
 func (r *CassandraReconciler) handleExternalChanges(c, iCassandra *v1beta1.Cassandra, l logr.Logger) (reconcile.Result, error) {
 	if !c.Spec.IsEqual(iCassandra.Spec) {
-		l.Info(msgSpecStillNoMatch,
+		l.Info(msgExternalChanges,
 			"specification of k8s resource", c.Spec,
 			"data from Instaclustr ", iCassandra.Spec)
 

--- a/controllers/clusters/helpers.go
+++ b/controllers/clusters/helpers.go
@@ -243,8 +243,6 @@ var msgExternalChanges = "The k8s specification is different from Instaclustr Co
 	"Update operations are blocked. Please check operator logs and edit the cluster spec manually, " +
 	"so that it would corresponds to the data from Instaclustr."
 
-var msgSpecStillNoMatch = "k8s resource specification still doesn't match with data on the Instaclustr Console. Double check the difference."
-
 // deleteDefaultUserSecret deletes the secret with default user credentials.
 // It ignores NotFound error.
 func deleteDefaultUserSecret(

--- a/controllers/clusters/kafkaconnect_controller.go
+++ b/controllers/clusters/kafkaconnect_controller.go
@@ -408,7 +408,7 @@ func (r *KafkaConnectReconciler) handleUpdateCluster(ctx context.Context, kc *v1
 
 func (r *KafkaConnectReconciler) handleExternalChanges(kc, ik *v1beta1.KafkaConnect, l logr.Logger) (reconcile.Result, error) {
 	if !kc.Spec.IsEqual(ik.Spec) {
-		l.Info(msgSpecStillNoMatch,
+		l.Info(msgExternalChanges,
 			"specification of k8s resource", kc.Spec,
 			"data from Instaclustr ", ik.Spec)
 

--- a/controllers/clusters/opensearch_controller.go
+++ b/controllers/clusters/opensearch_controller.go
@@ -404,7 +404,7 @@ func (r *OpenSearchReconciler) HandleUpdateCluster(
 
 func (r *OpenSearchReconciler) handleExternalChanges(o, iO *v1beta1.OpenSearch, l logr.Logger) (reconcile.Result, error) {
 	if !o.Spec.IsEqual(iO.Spec) {
-		l.Info(msgSpecStillNoMatch,
+		l.Info(msgExternalChanges,
 			"specification of k8s resource", o.Spec,
 			"data from Instaclustr ", iO.Spec)
 

--- a/controllers/clusters/postgresql_controller.go
+++ b/controllers/clusters/postgresql_controller.go
@@ -837,7 +837,7 @@ func (r *PostgreSQLReconciler) handleUserEvent(
 
 func (r *PostgreSQLReconciler) handleExternalChanges(pg, iPg *v1beta1.PostgreSQL, l logr.Logger) (reconcile.Result, error) {
 	if !pg.Spec.IsEqual(iPg.Spec) {
-		l.Info(msgSpecStillNoMatch,
+		l.Info(msgExternalChanges,
 			"specification of k8s resource", pg.Spec,
 			"data from Instaclustr ", iPg.Spec)
 		msgDiffSpecs, err := createSpecDifferenceMessage(pg.Spec, iPg.Spec)

--- a/controllers/clusters/suite_test.go
+++ b/controllers/clusters/suite_test.go
@@ -38,6 +38,7 @@ import (
 	clusterresourcescontrollers "github.com/instaclustr/operator/controllers/clusterresources"
 	"github.com/instaclustr/operator/pkg/instaclustr"
 	"github.com/instaclustr/operator/pkg/models"
+	"github.com/instaclustr/operator/pkg/ratelimiter"
 	"github.com/instaclustr/operator/pkg/scheduler"
 	//+kubebuilder:scaffold:imports
 )
@@ -155,6 +156,7 @@ var _ = BeforeSuite(func() {
 		API:           instaClient,
 		Scheduler:     scheduler.NewScheduler(logf.Log),
 		EventRecorder: eRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/clusters/zookeeper_controller.go
+++ b/controllers/clusters/zookeeper_controller.go
@@ -280,7 +280,7 @@ func (r *ZookeeperReconciler) handleExternalChanges(zook *v1beta1.Zookeeper, l l
 	}
 
 	if !zook.Spec.IsEqual(iZook.Spec) {
-		l.Info(msgSpecStillNoMatch,
+		l.Info(msgExternalChanges,
 			"specification of k8s resource", zook.Spec,
 			"data from Instaclustr ", iZook.Spec)
 

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 	clusterscontrollers "github.com/instaclustr/operator/controllers/clusters"
 	kafkamanagementcontrollers "github.com/instaclustr/operator/controllers/kafkamanagement"
 	"github.com/instaclustr/operator/pkg/instaclustr"
+	"github.com/instaclustr/operator/pkg/ratelimiter"
 	"github.com/instaclustr/operator/pkg/scheduler"
 	//+kubebuilder:scaffold:imports
 )
@@ -158,6 +159,7 @@ func main() {
 		API:           instaClient,
 		Scheduler:     s,
 		EventRecorder: eventRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Redis")
 		os.Exit(1)

--- a/pkg/ratelimiter/rate_limiter.go
+++ b/pkg/ratelimiter/rate_limiter.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	DefaultBaseDelay = 1 * time.Minute
-	DefaultMaxDelay  = 10 * time.Minute
-	defaultMaxTries  = 3
+	DefaultBaseDelay = 10 * time.Second
+	DefaultMaxDelay  = 1 * time.Minute
+	DefaultMaxTries  = 3
 )
 
 type ItemExponentialFailureRateLimiterWithMaxTries struct {
@@ -29,7 +29,7 @@ func NewItemExponentialFailureRateLimiterWithMaxTries(baseDelay time.Duration, m
 		failures:  map[interface{}]int{},
 		baseDelay: baseDelay,
 		maxDelay:  maxDelay,
-		maxTries:  defaultMaxTries,
+		maxTries:  DefaultMaxTries,
 	}
 }
 
@@ -44,7 +44,7 @@ func (r *ItemExponentialFailureRateLimiterWithMaxTries) When(item interface{}) t
 
 	if r.failures[item] > r.maxTries {
 		// reminder
-		return 60 * time.Minute
+		return 3 * time.Minute
 	}
 
 	if durationBackoff > r.maxDelay {


### PR DESCRIPTION
Add a functionality that invokes **external changes** on several failed update attempts. The PR fixes at least one known bug when scaling up the wrong number of nodes and as a result, you cannot reset the nodes' number because of the validation webhook (**external changes** can omit the webhook). 
Also, reducing the delaying time to speed up the limiter.
This PR is a good start to get rid of redundant annotation such as `UpdateQueuedAnnotation`
