### PR TITLE
External changes on several failed updates for all clusters

### DIFF
--- a/apis/clusters/v1beta1/cadence_types.go
+++ b/apis/clusters/v1beta1/cadence_types.go
@@ -403,6 +403,12 @@ func (cs *CadenceSpec) PrivateLinkFromInstAPI(iPLs []*models.PrivateLink) (pls [
 	return
 }
 
+func (c *Cadence) GetSpec() CadenceSpec { return c.Spec }
+
+func (c *Cadence) IsSpecEqual(spec CadenceSpec) bool {
+	return c.Spec.IsEqual(spec)
+}
+
 func (cs *CadenceSpec) IsEqual(spec CadenceSpec) bool {
 	return cs.AreDCsEqual(spec.DataCentres)
 }

--- a/apis/clusters/v1beta1/cassandra_types.go
+++ b/apis/clusters/v1beta1/cassandra_types.go
@@ -350,6 +350,12 @@ func (cs *CassandraSpec) IsEqual(spec CassandraSpec) bool {
 		cs.BundledUseOnly == spec.BundledUseOnly
 }
 
+func (c *Cassandra) GetSpec() CassandraSpec { return c.Spec }
+
+func (c *Cassandra) IsSpecEqual(spec CassandraSpec) bool {
+	return c.Spec.IsEqual(spec)
+}
+
 func (cs *CassandraSpec) AreDCsEqual(dcs []*CassandraDataCentre) bool {
 	if len(cs.DataCentres) != len(dcs) {
 		return false

--- a/apis/clusters/v1beta1/kafka_types.go
+++ b/apis/clusters/v1beta1/kafka_types.go
@@ -444,6 +444,12 @@ func (a *KafkaSpec) IsEqual(b KafkaSpec) bool {
 		a.IsTwoFactorDeleteEqual(b.TwoFactorDelete)
 }
 
+func (c *Kafka) GetSpec() KafkaSpec { return c.Spec }
+
+func (c *Kafka) IsSpecEqual(spec KafkaSpec) bool {
+	return c.Spec.IsEqual(spec)
+}
+
 func (rs *KafkaSpec) areDCsEqual(b []*KafkaDataCentre) bool {
 	a := rs.DataCentres
 	if len(a) != len(b) {

--- a/apis/clusters/v1beta1/kafkaconnect_types.go
+++ b/apis/clusters/v1beta1/kafkaconnect_types.go
@@ -321,6 +321,12 @@ func (ks *KafkaConnectStatus) DCsFromInstAPI(iDCs []*models.KafkaConnectDataCent
 	return
 }
 
+func (c *KafkaConnect) GetSpec() KafkaConnectSpec { return c.Spec }
+
+func (c *KafkaConnect) IsSpecEqual(spec KafkaConnectSpec) bool {
+	return c.Spec.IsEqual(spec)
+}
+
 func (ks *KafkaConnectSpec) IsEqual(kc KafkaConnectSpec) bool {
 	return ks.Cluster.IsEqual(kc.Cluster) &&
 		ks.AreDataCentresEqual(kc.DataCentres) &&

--- a/apis/clusters/v1beta1/opensearch_types.go
+++ b/apis/clusters/v1beta1/opensearch_types.go
@@ -409,6 +409,12 @@ func (oss *OpenSearchStatus) DCsFromInstAPI(iDCs []*models.OpenSearchDataCentre)
 	return
 }
 
+func (c *OpenSearch) GetSpec() OpenSearchSpec { return c.Spec }
+
+func (c *OpenSearch) IsSpecEqual(spec OpenSearchSpec) bool {
+	return c.Spec.IsEqual(spec)
+}
+
 func (a *OpenSearchSpec) IsEqual(b OpenSearchSpec) bool {
 	return a.Cluster.IsEqual(b.Cluster) &&
 		a.IsTwoFactorDeleteEqual(b.TwoFactorDelete) &&

--- a/apis/clusters/v1beta1/postgresql_types.go
+++ b/apis/clusters/v1beta1/postgresql_types.go
@@ -259,6 +259,12 @@ func (pdc *PgDataCentre) PGBouncerToInstAPI() (iPgB []*models.PGBouncer) {
 	return
 }
 
+func (c *PostgreSQL) GetSpec() PgSpec { return c.Spec }
+
+func (c *PostgreSQL) IsSpecEqual(spec PgSpec) bool {
+	return c.Spec.IsEqual(spec)
+}
+
 func (pgs *PgSpec) IsEqual(iPG PgSpec) bool {
 	return pgs.Cluster.IsEqual(iPG.Cluster) &&
 		pgs.SynchronousModeStrict == iPG.SynchronousModeStrict &&

--- a/apis/clusters/v1beta1/redis_types.go
+++ b/apis/clusters/v1beta1/redis_types.go
@@ -143,6 +143,12 @@ func (r *Redis) NewBackupSpec(startTimestamp int) *clusterresourcesv1beta1.Clust
 	}
 }
 
+func (c *Redis) GetSpec() RedisSpec { return c.Spec }
+
+func (c *Redis) IsSpecEqual(spec RedisSpec) bool {
+	return c.Spec.IsEqual(spec)
+}
+
 func (rs *RedisSpec) ToInstAPI() *models.RedisCluster {
 	return &models.RedisCluster{
 		Name:                   rs.Name,

--- a/apis/clusters/v1beta1/zookeeper_types.go
+++ b/apis/clusters/v1beta1/zookeeper_types.go
@@ -191,6 +191,10 @@ func (zdc *ZookeeperDataCentre) ToInstAPI() *models.ZookeeperDataCentre {
 	}
 }
 
+func (z *Zookeeper) GetSpec() ZookeeperSpec { return z.Spec }
+
+func (z *Zookeeper) IsSpecEqual(spec ZookeeperSpec) bool { return z.Spec.IsEqual(spec) }
+
 func (a *ZookeeperSpec) IsEqual(b ZookeeperSpec) bool {
 	return a.Cluster.IsEqual(b.Cluster) &&
 		a.areDCsEqual(b.DataCentres)

--- a/controllers/clusters/suite_test.go
+++ b/controllers/clusters/suite_test.go
@@ -111,6 +111,7 @@ var _ = BeforeSuite(func() {
 		API:           instaClient,
 		Scheduler:     scheduler.NewScheduler(logf.Log),
 		EventRecorder: eRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -120,6 +121,7 @@ var _ = BeforeSuite(func() {
 		API:           instaClient,
 		Scheduler:     scheduler.NewScheduler(logf.Log),
 		EventRecorder: eRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -129,6 +131,7 @@ var _ = BeforeSuite(func() {
 		API:           instaClient,
 		Scheduler:     scheduler.NewScheduler(logf.Log),
 		EventRecorder: eRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -138,6 +141,7 @@ var _ = BeforeSuite(func() {
 		API:           instaClient,
 		Scheduler:     scheduler.NewScheduler(logf.Log),
 		EventRecorder: eRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -147,6 +151,7 @@ var _ = BeforeSuite(func() {
 		API:           instaClient,
 		Scheduler:     scheduler.NewScheduler(logf.Log),
 		EventRecorder: eRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -166,6 +171,7 @@ var _ = BeforeSuite(func() {
 		API:           instaClient,
 		Scheduler:     scheduler.NewScheduler(logf.Log),
 		EventRecorder: eRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -175,6 +181,7 @@ var _ = BeforeSuite(func() {
 		API:           instaClient,
 		Scheduler:     scheduler.NewScheduler(logf.Log),
 		EventRecorder: eRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/tests/suite_test.go
+++ b/controllers/tests/suite_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/instaclustr/operator/controllers/clusters"
 	"github.com/instaclustr/operator/pkg/instaclustr"
 	"github.com/instaclustr/operator/pkg/models"
+	"github.com/instaclustr/operator/pkg/ratelimiter"
 	"github.com/instaclustr/operator/pkg/scheduler"
 	//+kubebuilder:scaffold:imports
 )
@@ -109,6 +110,7 @@ var _ = BeforeSuite(func() {
 		API:           instaClient,
 		Scheduler:     scheduler.NewScheduler(logf.Log),
 		EventRecorder: eRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -126,6 +128,7 @@ var _ = BeforeSuite(func() {
 		API:           instaClient,
 		Scheduler:     scheduler.NewScheduler(logf.Log),
 		EventRecorder: eRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -129,6 +129,7 @@ func main() {
 		API:           instaClient,
 		Scheduler:     s,
 		EventRecorder: eventRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cassandra")
 		os.Exit(1)
@@ -139,6 +140,7 @@ func main() {
 		API:           instaClient,
 		Scheduler:     s,
 		EventRecorder: eventRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PostgreSQL")
 		os.Exit(1)
@@ -149,6 +151,7 @@ func main() {
 		API:           instaClient,
 		Scheduler:     s,
 		EventRecorder: eventRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenSearch")
 		os.Exit(1)
@@ -170,6 +173,7 @@ func main() {
 		API:           instaClient,
 		Scheduler:     s,
 		EventRecorder: eventRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cadence")
 		os.Exit(1)
@@ -180,6 +184,7 @@ func main() {
 		API:           instaClient,
 		Scheduler:     s,
 		EventRecorder: eventRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Kafka")
 		os.Exit(1)
@@ -220,6 +225,7 @@ func main() {
 		API:           instaClient,
 		Scheduler:     s,
 		EventRecorder: eventRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KafkaConnect")
 		os.Exit(1)
@@ -268,6 +274,7 @@ func main() {
 		API:           instaClient,
 		Scheduler:     s,
 		EventRecorder: eventRecorder,
+		RateLimiter:   ratelimiter.NewItemExponentialFailureRateLimiterWithMaxTries(ratelimiter.DefaultBaseDelay, ratelimiter.DefaultMaxDelay),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Zookeeper")
 		os.Exit(1)

--- a/pkg/models/operator.go
+++ b/pkg/models/operator.go
@@ -28,7 +28,6 @@ const (
 	ExternalChangesAnnotation = "instaclustr.com/externalChanges"
 	DeletionFinalizer         = "instaclustr.com/deletionFinalizer"
 	StartTimestampAnnotation  = "instaclustr.com/startTimestamp"
-	UpdateQueuedAnnotation    = "instaclustr.com/updateQueued"
 
 	DefaultSecretLabel                = "instaclustr.com/defaultSecret"
 	ControlledByLabel                 = "instaclustr.com/controlledBy"


### PR DESCRIPTION
Refactor the codebase by eliminating the `UpdateQueuedAnnotation` annotation and unnecessary redundancy in handling external changes. This PR enhances code clarity and readability, resulting in a cleaner implementation. Now the operator handles InstAPI Update errors - after several errors, the operator returns external changes and blocks the update operation