### PR TITLE
pre-commit hook was added, .env and creds-secret were removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,4 @@ testbin/*
 *.swo
 *~
 
-# environment file
-.env
-
-# personal developer's secret
-config/manager/creds_secret.yaml
-
 config/manager/kustomization.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  -   repo: https://github.com/Yelp/detect-secrets
+      rev: v1.4.0
+      hooks:
+        -   id: detect-secrets
+            args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,1174 @@
+{
+  "version": "1.4.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "^vendor/"
+      ]
+    }
+  ],
+  "results": {
+    "apis/clusterresources/v1beta1/cassandrauser_types.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusterresources/v1beta1/cassandrauser_types.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 72
+      }
+    ],
+    "apis/clusterresources/v1beta1/opensearchuser_types.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusterresources/v1beta1/opensearchuser_types.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 62
+      }
+    ],
+    "apis/clusterresources/v1beta1/postgresqluser_types.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusterresources/v1beta1/postgresqluser_types.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 82
+      }
+    ],
+    "apis/clusterresources/v1beta1/redisuser_types.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusterresources/v1beta1/redisuser_types.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 64
+      }
+    ],
+    "apis/clusterresources/v1beta1/structs.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusterresources/v1beta1/structs.go",
+        "hashed_secret": "e03127a337f643c1c0eb2b0e8683e9140e19120d",
+        "is_verified": false,
+        "line_number": 65
+      }
+    ],
+    "apis/clusterresources/v1beta1/zz_generated.deepcopy.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusterresources/v1beta1/zz_generated.deepcopy.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 548
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusterresources/v1beta1/zz_generated.deepcopy.go",
+        "hashed_secret": "44864ab66d6b2c4df1459dc1e597a82f957dab32",
+        "is_verified": false,
+        "line_number": 684
+      }
+    ],
+    "apis/clusters/v1beta1/cadence_types.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/cadence_types.go",
+        "hashed_secret": "a242f4a16b957f7ff99eb24e189e94d270d2348b",
+        "is_verified": false,
+        "line_number": 281
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/cadence_types.go",
+        "hashed_secret": "a57ce131bd944bdf8ba2f2f93e179dc416ed0315",
+        "is_verified": false,
+        "line_number": 291
+      }
+    ],
+    "apis/clusters/v1beta1/cassandra_types.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/cassandra_types.go",
+        "hashed_secret": "4d2d63a69bc8074b20a4edcdcbbfa2b81d791543",
+        "is_verified": false,
+        "line_number": 257
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/cassandra_types.go",
+        "hashed_secret": "e0a46b27231f798fe22dc4d5d82b5feeb5dcf085",
+        "is_verified": false,
+        "line_number": 313
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/cassandra_types.go",
+        "hashed_secret": "e7f873437cda278898e12c04e623fcbefc193cb8",
+        "is_verified": false,
+        "line_number": 349
+      }
+    ],
+    "apis/clusters/v1beta1/cassandra_webhook.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/cassandra_webhook.go",
+        "hashed_secret": "e0a46b27231f798fe22dc4d5d82b5feeb5dcf085",
+        "is_verified": false,
+        "line_number": 260
+      }
+    ],
+    "apis/clusters/v1beta1/kafka_types.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafka_types.go",
+        "hashed_secret": "964c67cddfe8e6707157152dcf319126502199dc",
+        "is_verified": false,
+        "line_number": 206
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafka_types.go",
+        "hashed_secret": "75ba0f10db4ab09467225d44f7911a3f724a0917",
+        "is_verified": false,
+        "line_number": 374
+      }
+    ],
+    "apis/clusters/v1beta1/kafkaconnect_types.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafkaconnect_types.go",
+        "hashed_secret": "46fe9b29395041087f91b33bd8c5c6177cd42fd1",
+        "is_verified": false,
+        "line_number": 247
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafkaconnect_types.go",
+        "hashed_secret": "4b3af1508421e2fa591c5b260c36dd06fdd872a5",
+        "is_verified": false,
+        "line_number": 285
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafkaconnect_types.go",
+        "hashed_secret": "cf45830dd81b7e1a8b5ffbc2d95b112771524117",
+        "is_verified": false,
+        "line_number": 295
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafkaconnect_types.go",
+        "hashed_secret": "138905ac46675150bf790088ec56b2efc6a64697",
+        "is_verified": false,
+        "line_number": 306
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafkaconnect_types.go",
+        "hashed_secret": "3948059919ffeee8ecc42149cb386f43d2f06f74",
+        "is_verified": false,
+        "line_number": 311
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafkaconnect_types.go",
+        "hashed_secret": "87f1180476a944c4162d1af55efedc8f3e3b609c",
+        "is_verified": false,
+        "line_number": 520
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafkaconnect_types.go",
+        "hashed_secret": "f0f06c9167ce61a586749bb183ac6a3756dd6010",
+        "is_verified": false,
+        "line_number": 530
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafkaconnect_types.go",
+        "hashed_secret": "2042128e13ef5ede4af44271160c72f64564c632",
+        "is_verified": false,
+        "line_number": 541
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafkaconnect_types.go",
+        "hashed_secret": "82dc9ca8ba09262ce948227aeb5d9db8084eeb5d",
+        "is_verified": false,
+        "line_number": 546
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafkaconnect_types.go",
+        "hashed_secret": "5f915325aef923cdc945f639f14c2f854b4214d6",
+        "is_verified": false,
+        "line_number": 570
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafkaconnect_types.go",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 603
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/kafkaconnect_types.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 608
+      }
+    ],
+    "apis/clusters/v1beta1/postgresql_types.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/postgresql_types.go",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 374
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/postgresql_types.go",
+        "hashed_secret": "a3d7d4a96d18c8fc5a1cf9c9c01c45b4690b4008",
+        "is_verified": false,
+        "line_number": 380
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/postgresql_types.go",
+        "hashed_secret": "a57ce131bd944bdf8ba2f2f93e179dc416ed0315",
+        "is_verified": false,
+        "line_number": 500
+      }
+    ],
+    "apis/clusters/v1beta1/redis_types.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/redis_types.go",
+        "hashed_secret": "bc1c5ae5fd4a238d86261f422e62c489de408c22",
+        "is_verified": false,
+        "line_number": 159
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/redis_types.go",
+        "hashed_secret": "d62d56668a8c859e768e8250ed2fb690d03cead3",
+        "is_verified": false,
+        "line_number": 228
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/redis_types.go",
+        "hashed_secret": "5ba903f624ef2afb380a91d9c08efed6ef1c531d",
+        "is_verified": false,
+        "line_number": 281
+      }
+    ],
+    "apis/clusters/v1beta1/redis_webhook.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/redis_webhook.go",
+        "hashed_secret": "bc1c5ae5fd4a238d86261f422e62c489de408c22",
+        "is_verified": false,
+        "line_number": 340
+      }
+    ],
+    "apis/clusters/v1beta1/zookeeper_types.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/zookeeper_types.go",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 234
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/clusters/v1beta1/zookeeper_types.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 239
+      }
+    ],
+    "apis/kafkamanagement/v1beta1/kafkauser_types.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/kafkamanagement/v1beta1/kafkauser_types.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 105
+      }
+    ],
+    "apis/kafkamanagement/v1beta1/usercertificate_webhook.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/kafkamanagement/v1beta1/usercertificate_webhook.go",
+        "hashed_secret": "3747c0c1bc4416dc2334f5aff52f3c9df602d92d",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/kafkamanagement/v1beta1/usercertificate_webhook.go",
+        "hashed_secret": "11495ec6584371b5d9982b538de7b47957781c13",
+        "is_verified": false,
+        "line_number": 49
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/kafkamanagement/v1beta1/usercertificate_webhook.go",
+        "hashed_secret": "7eb7eabdf6b5b4f62b12c2b706192d408f95a3c0",
+        "is_verified": false,
+        "line_number": 62
+      }
+    ],
+    "apis/kafkamanagement/v1beta1/zz_generated.deepcopy.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/kafkamanagement/v1beta1/zz_generated.deepcopy.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 245
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "apis/kafkamanagement/v1beta1/zz_generated.deepcopy.go",
+        "hashed_secret": "851d330e2593f42f560f292b47001e46ebaba857",
+        "is_verified": false,
+        "line_number": 667
+      }
+    ],
+    "config/certmanager/certificate.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "config/certmanager/certificate.yaml",
+        "hashed_secret": "3fd17df2e1dedb2d4513d9335da31ccec5ef3b6b",
+        "is_verified": false,
+        "line_number": 39
+      }
+    ],
+    "config/default/manager_webhook_patch.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "config/default/manager_webhook_patch.yaml",
+        "hashed_secret": "4e052001c466da91831f00f114a861e9e02ce521",
+        "is_verified": false,
+        "line_number": 23
+      }
+    ],
+    "config/samples/clusterresources_v1beta1_cassandrauser.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "config/samples/clusterresources_v1beta1_cassandrauser.yaml",
+        "hashed_secret": "db714666eea01ec2bc9b0c39eeab040c3075b695",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
+    "config/samples/clusterresources_v1beta1_opensearchuser.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "config/samples/clusterresources_v1beta1_opensearchuser.yaml",
+        "hashed_secret": "9ae7fcd514a21692ffa623319f840042442ad010",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "config/samples/clusterresources_v1beta1_postgresqluser.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "config/samples/clusterresources_v1beta1_postgresqluser.yaml",
+        "hashed_secret": "db714666eea01ec2bc9b0c39eeab040c3075b695",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
+    "config/samples/clusterresources_v1beta1_redisuser.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "config/samples/clusterresources_v1beta1_redisuser.yaml",
+        "hashed_secret": "0188383b4fcf68962da89582db07e26a43a08887",
+        "is_verified": false,
+        "line_number": 7
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "config/samples/clusterresources_v1beta1_redisuser.yaml",
+        "hashed_secret": "a104346282348b87a0ed5dc4f505717ee9f8b4a9",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "config/samples/clusterresources_v1beta1_redisuser.yaml",
+        "hashed_secret": "f5eff5064558de41ed63ee320a560a81dc115afb",
+        "is_verified": false,
+        "line_number": 23
+      }
+    ],
+    "config/samples/kafkamanagement_v1beta1_kafkauser.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "config/samples/kafkamanagement_v1beta1_kafkauser.yaml",
+        "hashed_secret": "34405c5b7fc705cae194b32ee408fd2bb7be0809",
+        "is_verified": false,
+        "line_number": 7
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "config/samples/kafkamanagement_v1beta1_kafkauser.yaml",
+        "hashed_secret": "34405c5b7fc705cae194b32ee408fd2bb7be0809",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "controllers/clusterresources/postgresqluser_controller.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/clusterresources/postgresqluser_controller.go",
+        "hashed_secret": "d7b035bd4516a073375fc3f385b16ab026eb8492",
+        "is_verified": false,
+        "line_number": 151
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "controllers/clusterresources/postgresqluser_controller.go",
+        "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
+        "is_verified": false,
+        "line_number": 345
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/clusterresources/postgresqluser_controller.go",
+        "hashed_secret": "dfe914dad87f58ca3fbf9e77036e1add2070da45",
+        "is_verified": false,
+        "line_number": 386
+      }
+    ],
+    "controllers/clusters/cadence_controller.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/clusters/cadence_controller.go",
+        "hashed_secret": "bcf196cdeea4d7ed8b04dcbbd40111eb5e9abeac",
+        "is_verified": false,
+        "line_number": 773
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/clusters/cadence_controller.go",
+        "hashed_secret": "192d703e91a60432ce06bfe26adfd12f5c7b931f",
+        "is_verified": false,
+        "line_number": 815
+      }
+    ],
+    "controllers/clusters/datatest/kafka_v1beta1.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/clusters/datatest/kafka_v1beta1.yaml",
+        "hashed_secret": "92429d82a41e930486c6de5ebda9602d55c39986",
+        "is_verified": false,
+        "line_number": 39
+      }
+    ],
+    "controllers/clusters/datatest/kafkaconnect_v1beta1.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/clusters/datatest/kafkaconnect_v1beta1.yaml",
+        "hashed_secret": "0f354ff8e8d0a09b5b3f1720669ef6f1b6f12901",
+        "is_verified": false,
+        "line_number": 51
+      }
+    ],
+    "controllers/clusters/kafkaconnect_controller_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/clusters/kafkaconnect_controller_test.go",
+        "hashed_secret": "a57ce131bd944bdf8ba2f2f93e179dc416ed0315",
+        "is_verified": false,
+        "line_number": 72
+      }
+    ],
+    "controllers/clusters/postgresql_controller.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/clusters/postgresql_controller.go",
+        "hashed_secret": "a57ce131bd944bdf8ba2f2f93e179dc416ed0315",
+        "is_verified": false,
+        "line_number": 576
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/clusters/postgresql_controller.go",
+        "hashed_secret": "b5d01701d58992dc3e388a02b55f1780c5e395a4",
+        "is_verified": false,
+        "line_number": 597
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/clusters/postgresql_controller.go",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 1674
+      }
+    ],
+    "controllers/clusters/zookeeper_controller_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/clusters/zookeeper_controller_test.go",
+        "hashed_secret": "a57ce131bd944bdf8ba2f2f93e179dc416ed0315",
+        "is_verified": false,
+        "line_number": 70
+      }
+    ],
+    "controllers/kafkamanagement/datatest/kafkauser_v1beta1_secret.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "controllers/kafkamanagement/datatest/kafkauser_v1beta1_secret.yaml",
+        "hashed_secret": "34405c5b7fc705cae194b32ee408fd2bb7be0809",
+        "is_verified": false,
+        "line_number": 8
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/kafkamanagement/datatest/kafkauser_v1beta1_secret.yaml",
+        "hashed_secret": "34405c5b7fc705cae194b32ee408fd2bb7be0809",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "controllers/kafkamanagement/kafkauser_controller.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/kafkamanagement/kafkauser_controller.go",
+        "hashed_secret": "a57ce131bd944bdf8ba2f2f93e179dc416ed0315",
+        "is_verified": false,
+        "line_number": 85
+      }
+    ],
+    "controllers/kafkamanagement/usercertificate_controller.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/kafkamanagement/usercertificate_controller.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 107
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/kafkamanagement/usercertificate_controller.go",
+        "hashed_secret": "9b7d30011be6013933888f8eb49acaeda004678d",
+        "is_verified": false,
+        "line_number": 211
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/kafkamanagement/usercertificate_controller.go",
+        "hashed_secret": "ad57fd29d1f6c85fdf13d5458662469f430a15fd",
+        "is_verified": false,
+        "line_number": 241
+      }
+    ],
+    "controllers/tests/cassandra_plus_users_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/tests/cassandra_plus_users_test.go",
+        "hashed_secret": "b91eb77ecadb52ef150c38bd532e466059649e0a",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/tests/cassandra_plus_users_test.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 74
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/tests/cassandra_plus_users_test.go",
+        "hashed_secret": "3a00989b1ac348f4c7fe620f87ab99f929769a33",
+        "is_verified": false,
+        "line_number": 92
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/tests/cassandra_plus_users_test.go",
+        "hashed_secret": "5cec175b165e3d5e62c9e13ce848ef6feac81bff",
+        "is_verified": false,
+        "line_number": 210
+      }
+    ],
+    "controllers/tests/opensearch_plus_users_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/tests/opensearch_plus_users_test.go",
+        "hashed_secret": "b91eb77ecadb52ef150c38bd532e466059649e0a",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/tests/opensearch_plus_users_test.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 73
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/tests/opensearch_plus_users_test.go",
+        "hashed_secret": "3a00989b1ac348f4c7fe620f87ab99f929769a33",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "controllers/tests/opensearch_plus_users_test.go",
+        "hashed_secret": "5cec175b165e3d5e62c9e13ce848ef6feac81bff",
+        "is_verified": false,
+        "line_number": 207
+      }
+    ],
+    "doc/clusters/kafka.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "doc/clusters/kafka.md",
+        "hashed_secret": "92429d82a41e930486c6de5ebda9602d55c39986",
+        "is_verified": false,
+        "line_number": 166
+      }
+    ],
+    "doc/kafkamanagment/kafka-user.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "doc/kafkamanagment/kafka-user.md",
+        "hashed_secret": "bd7f1f83907b21df069220af64956dad72d52b04",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "doc/kafkamanagment/kafka-user.md",
+        "hashed_secret": "bd7f1f83907b21df069220af64956dad72d52b04",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "doc/kafkamanagment/kafka-user.md",
+        "hashed_secret": "5332dacad20a47ed30ac276f31420d348a122341",
+        "is_verified": false,
+        "line_number": 37
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "doc/kafkamanagment/kafka-user.md",
+        "hashed_secret": "7505d64a54e061b7acd54ccd58b49dc43500b635",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
+    "pkg/instaclustr/client.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/client.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 2017
+      }
+    ],
+    "pkg/instaclustr/mock/client.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/client.go",
+        "hashed_secret": "6d8a9028dbff8f55b1a86a3888d1dd13f916f2b9",
+        "is_verified": false,
+        "line_number": 350
+      }
+    ],
+    "pkg/instaclustr/mock/server/api/openapi.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/api/openapi.yaml",
+        "hashed_secret": "a4dbc4c842a38795c9f5c1a0b4ad25d168aec263",
+        "is_verified": false,
+        "line_number": 5206
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/api/openapi.yaml",
+        "hashed_secret": "18344ab22a5c55d7a22ecf4597493e1d539736aa",
+        "is_verified": false,
+        "line_number": 10456
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/api/openapi.yaml",
+        "hashed_secret": "98befe20e4f1a56f01994305a2b89245147ed65e",
+        "is_verified": false,
+        "line_number": 11008
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/api/openapi.yaml",
+        "hashed_secret": "de4c9837c605f1db3cd9168fc9c078b1acdfe62b",
+        "is_verified": false,
+        "line_number": 14015
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/api_apache_kafka_rest_proxy_user.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pkg/instaclustr/mock/server/go/api_apache_kafka_rest_proxy_user.go",
+        "hashed_secret": "0d4d9cf6a87f334c932f8f1a4d81e0226cc18fbc",
+        "is_verified": false,
+        "line_number": 58
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/api_apache_kafka_rest_proxy_user.go",
+        "hashed_secret": "eaa0ff4ff375003149a5d645ca81de75a5239b51",
+        "is_verified": false,
+        "line_number": 58
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/api_apache_kafka_rest_proxy_user.go",
+        "hashed_secret": "25b955e880137e7822c0ac8f54e44783c7873f50",
+        "is_verified": false,
+        "line_number": 85
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/api_apache_kafka_schema_registry_user.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/api_apache_kafka_schema_registry_user.go",
+        "hashed_secret": "eaa0ff4ff375003149a5d645ca81de75a5239b51",
+        "is_verified": false,
+        "line_number": 58
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pkg/instaclustr/mock/server/go/api_apache_kafka_schema_registry_user.go",
+        "hashed_secret": "f4b1d36227c0153945a18c9721099f906c2a1133",
+        "is_verified": false,
+        "line_number": 58
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/api_apache_kafka_schema_registry_user.go",
+        "hashed_secret": "b0c7cf58570bf3060392eeae1e1e7c1f671a3e7a",
+        "is_verified": false,
+        "line_number": 85
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/api_apache_kafka_topic_v2.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pkg/instaclustr/mock/server/go/api_apache_kafka_topic_v2.go",
+        "hashed_secret": "a8177d754d3fdae6bb70d94b87b7d5dcf3098013",
+        "is_verified": false,
+        "line_number": 58
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/api_aws_encryption_key_v2.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pkg/instaclustr/mock/server/go/api_aws_encryption_key_v2.go",
+        "hashed_secret": "f0cb5e4f4aa2008023a1e8386390558474144857",
+        "is_verified": false,
+        "line_number": 53
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/api_bundle_user_service.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/api_bundle_user_service.go",
+        "hashed_secret": "f2d762021e15f67e3f6c6ccfc11c255368c78bd3",
+        "is_verified": false,
+        "line_number": 113
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/api_karapace_rest_proxy_user.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/api_karapace_rest_proxy_user.go",
+        "hashed_secret": "eaa0ff4ff375003149a5d645ca81de75a5239b51",
+        "is_verified": false,
+        "line_number": 58
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/api_karapace_rest_proxy_user.go",
+        "hashed_secret": "d67f07225adaedcad98b77e3806e9d549197663d",
+        "is_verified": false,
+        "line_number": 85
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/api_karapace_schema_registry_user.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/api_karapace_schema_registry_user.go",
+        "hashed_secret": "eaa0ff4ff375003149a5d645ca81de75a5239b51",
+        "is_verified": false,
+        "line_number": 58
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/api_karapace_schema_registry_user.go",
+        "hashed_secret": "a45d2860557ff66bd1c6c61cb506d0051dd22a0a",
+        "is_verified": false,
+        "line_number": 85
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/api_postgre_sql_user_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/api_postgre_sql_user_v2.go",
+        "hashed_secret": "eaa0ff4ff375003149a5d645ca81de75a5239b51",
+        "is_verified": false,
+        "line_number": 53
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/api_redis_user_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/api_redis_user_v2.go",
+        "hashed_secret": "9de6a76549d3c9c73aeae29a5d5d9e328248171f",
+        "is_verified": false,
+        "line_number": 154
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_bundle_user_create_request.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_bundle_user_create_request.go",
+        "hashed_secret": "415c2814e8941222d7dfbcf0bba5f0086cb4465b",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_cassandra_cluster_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_cassandra_cluster_v2.go",
+        "hashed_secret": "8e88e5f50078adf70f0b77f1807b6969e6892d89",
+        "is_verified": false,
+        "line_number": 72
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_kafka_connect_custom_connectors_azure_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_kafka_connect_custom_connectors_azure_v2.go",
+        "hashed_secret": "2006a6bad012d08458b815b31c44b946622b43d4",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_kafka_connect_custom_connectors_gcp_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_kafka_connect_custom_connectors_gcp_v2.go",
+        "hashed_secret": "01822d27def46509a9f8348f5dfbd0a6f20e84c5",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_kafka_connect_custom_connectors_gcp_v2.go",
+        "hashed_secret": "25ab1c5b3334881fe7ce31de51342aec79cfa61c",
+        "is_verified": false,
+        "line_number": 41
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_kafka_rest_proxy_user_password_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_kafka_rest_proxy_user_password_v2.go",
+        "hashed_secret": "415c2814e8941222d7dfbcf0bba5f0086cb4465b",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_kafka_schema_registry_user_password_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_kafka_schema_registry_user_password_v2.go",
+        "hashed_secret": "415c2814e8941222d7dfbcf0bba5f0086cb4465b",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_kafka_user_update_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_kafka_user_update_v2.go",
+        "hashed_secret": "415c2814e8941222d7dfbcf0bba5f0086cb4465b",
+        "is_verified": false,
+        "line_number": 35
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_kafka_user_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_kafka_user_v2.go",
+        "hashed_secret": "415c2814e8941222d7dfbcf0bba5f0086cb4465b",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_karapace_rest_proxy_user_password_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_karapace_rest_proxy_user_password_v2.go",
+        "hashed_secret": "415c2814e8941222d7dfbcf0bba5f0086cb4465b",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_karapace_schema_registry_user_password_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_karapace_schema_registry_user_password_v2.go",
+        "hashed_secret": "415c2814e8941222d7dfbcf0bba5f0086cb4465b",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_postgresql_user_summary.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_postgresql_user_summary.go",
+        "hashed_secret": "415c2814e8941222d7dfbcf0bba5f0086cb4465b",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_redis_cluster_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_redis_cluster_v2.go",
+        "hashed_secret": "8e88e5f50078adf70f0b77f1807b6969e6892d89",
+        "is_verified": false,
+        "line_number": 63
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_redis_user_password_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_redis_user_password_v2.go",
+        "hashed_secret": "415c2814e8941222d7dfbcf0bba5f0086cb4465b",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "pkg/instaclustr/mock/server/go/model_redis_user_v2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/instaclustr/mock/server/go/model_redis_user_v2.go",
+        "hashed_secret": "415c2814e8941222d7dfbcf0bba5f0086cb4465b",
+        "is_verified": false,
+        "line_number": 34
+      }
+    ],
+    "pkg/models/cadence_apiv2.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/models/cadence_apiv2.go",
+        "hashed_secret": "2d8ca9a11a2e2ef6931d0f0ef52b1896114a4558",
+        "is_verified": false,
+        "line_number": 21
+      }
+    ],
+    "pkg/models/on_premises.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/models/on_premises.go",
+        "hashed_secret": "da29522ee0860b12cb0ec830c83c9a81478fad0f",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "pkg/models/operator.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/models/operator.go",
+        "hashed_secret": "b021a4982481503b77dfa4c9e34dbd935c5121cc",
+        "is_verified": false,
+        "line_number": 32
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/models/operator.go",
+        "hashed_secret": "f4e7a8740db0b7a0bfd8e63077261475f61fc2a6",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/models/operator.go",
+        "hashed_secret": "7d4e4f654101e1514e18672295dfd53b64e7e5ee",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/models/operator.go",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 122
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/models/operator.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 150
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/models/operator.go",
+        "hashed_secret": "d65d45369e8aef106a8ca1c3bad151ad24163494",
+        "is_verified": false,
+        "line_number": 180
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/models/operator.go",
+        "hashed_secret": "638724dcc0799a22cc4adce12434fcac73c8af58",
+        "is_verified": false,
+        "line_number": 181
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/models/operator.go",
+        "hashed_secret": "4fe486f255f36f8787d5c5cc1185e3d5d5c91c03",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/models/operator.go",
+        "hashed_secret": "2331919a92cbb5c2d530947171fa5e1a1415af2f",
+        "is_verified": false,
+        "line_number": 183
+      }
+    ],
+    "scripts/cloud-init-secret.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/cloud-init-secret.yaml",
+        "hashed_secret": "302bf518f7d8be886ebfd2f1b065b25ac400f750",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ]
+  },
+  "generated_at": "2024-01-31T10:27:15Z"
+}

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	cd scripts && ./make_creds_secret.sh
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	kubectl apply -f ~/creds_secret.yaml
 
 .PHONY: helm-deploy
 helm-deploy:
@@ -228,3 +229,8 @@ install-virtctl: ## Install virtctl tool
 	chmod +x virtctl
 	sudo install virtctl /usr/local/bin
 	rm virtctl
+
+.PHONY: install-pre-commit
+install-pre-commit:
+	pip install pre-commit
+	pre-commit install

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 **Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
 ### Running on the cluster
-1. Create the .env file, copy all content from the .env.tmpl and fill variables. When the operator deploys, it will create the secret from these variables to access the Instaclustr API.
+1. Create the .env file inside your home folder (~/.env), copy all content from the .env.tmpl and fill variables. When the operator deploys, it will create the secret from these variables to access the Instaclustr API.
 Create the config/manager/kustomization.yaml file and copy all content from the config/manager/kustomization.yaml.tmpl.
 
 2. Deploy the cert-manager:

--- a/config/manager/kustomization.yaml.tmpl
+++ b/config/manager/kustomization.yaml.tmpl
@@ -1,6 +1,5 @@
 resources:
 - manager.yaml
-- creds_secret.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/scripts/make_creds_secret.sh
+++ b/scripts/make_creds_secret.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-path=$(readlink -f ../.env)
+path=$(readlink -f ~/.env)
 
 . $path
 export USERNAME=$(echo -n $USERNAME | base64)
 export APIKEY=$(echo -n $APIKEY | base64)
 export HOSTNAME=$(echo -n $HOSTNAME | base64)
 
-( echo "cat <<EOF >../config/manager/creds_secret.yaml";
+( echo "cat <<EOF >~/creds_secret.yaml";
   cat secret.yaml;
   echo "EOF";
 ) >tmp.yaml
 . tmp.yaml
-cat ../config/manager/creds_secret.yaml
+cat ~/creds_secret.yaml
 rm tmp.yaml

--- a/scripts/secret.yaml
+++ b/scripts/secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: creds-secret
-  namespace: system
+  namespace: operator-system
 type: Opaque
 data:
   USERNAME: $USERNAME


### PR DESCRIPTION
Pre-commit hooks activate when a developer attempts to commit code containing secret information. 

However, a significant drawback of this approach is that each developer must install the pre-commit Python application and set up the hook in their local .git environment.