### PR TITLE
Cluster Sync Event

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1089,35 +1089,35 @@
         "filename": "pkg/models/operator.go",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 153
+        "line_number": 154
       },
       {
         "type": "Secret Keyword",
         "filename": "pkg/models/operator.go",
         "hashed_secret": "d65d45369e8aef106a8ca1c3bad151ad24163494",
         "is_verified": false,
-        "line_number": 183
+        "line_number": 184
       },
       {
         "type": "Secret Keyword",
         "filename": "pkg/models/operator.go",
         "hashed_secret": "638724dcc0799a22cc4adce12434fcac73c8af58",
         "is_verified": false,
-        "line_number": 184
+        "line_number": 185
       },
       {
         "type": "Secret Keyword",
         "filename": "pkg/models/operator.go",
         "hashed_secret": "4fe486f255f36f8787d5c5cc1185e3d5d5c91c03",
         "is_verified": false,
-        "line_number": 185
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "pkg/models/operator.go",
         "hashed_secret": "2331919a92cbb5c2d530947171fa5e1a1415af2f",
         "is_verified": false,
-        "line_number": 186
+        "line_number": 187
       }
     ],
     "pkg/utils/user_creds_from_secret_test.go": [
@@ -1146,5 +1146,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-16T12:41:16Z"
+  "generated_at": "2024-02-19T13:01:03Z"
 }

--- a/apis/clusters/v1beta1/cassandra_webhook.go
+++ b/apis/clusters/v1beta1/cassandra_webhook.go
@@ -151,8 +151,12 @@ func (cv *cassandraValidator) ValidateUpdate(ctx context.Context, old runtime.Ob
 		return fmt.Errorf("cannot assert object %v to cassandra", new.GetObjectKind())
 	}
 
+	if c.Annotations[models.ResourceStateAnnotation] == models.SyncingEvent {
+		return nil
+	}
+
 	// skip validation when we receive cluster specification update from the Instaclustr Console.
-	if c.Annotations[models.ResourceStateAnnotation] == models.CreatingEvent {
+	if c.Annotations[models.ExternalChangesAnnotation] == models.True {
 		return nil
 	}
 
@@ -161,10 +165,6 @@ func (cv *cassandraValidator) ValidateUpdate(ctx context.Context, old runtime.Ob
 	}
 
 	cassandralog.Info("validate update", "name", c.Name)
-
-	if c.Annotations[models.ExternalChangesAnnotation] == models.True {
-		return nil
-	}
 
 	oldCluster, ok := old.(*Cassandra)
 	if !ok {

--- a/apis/clusters/v1beta1/kafka_webhook.go
+++ b/apis/clusters/v1beta1/kafka_webhook.go
@@ -171,7 +171,12 @@ func (kv *kafkaValidator) ValidateUpdate(ctx context.Context, old runtime.Object
 		return fmt.Errorf("cannot assert object %v to kafka", new.GetObjectKind())
 	}
 
-	if k.Annotations[models.ResourceStateAnnotation] == models.CreatingEvent {
+	if k.Annotations[models.ResourceStateAnnotation] == models.SyncingEvent {
+		return nil
+	}
+
+	// skip validation when handle external changes from Instaclustr
+	if k.Annotations[models.ExternalChangesAnnotation] == models.True {
 		return nil
 	}
 
@@ -180,11 +185,6 @@ func (kv *kafkaValidator) ValidateUpdate(ctx context.Context, old runtime.Object
 	}
 
 	kafkalog.Info("validate update", "name", k.Name)
-
-	// skip validation when handle external changes from Instaclustr
-	if k.Annotations[models.ExternalChangesAnnotation] == models.True {
-		return nil
-	}
 
 	oldKafka, ok := old.(*Kafka)
 	if !ok {

--- a/apis/clusters/v1beta1/opensearch_webhook.go
+++ b/apis/clusters/v1beta1/opensearch_webhook.go
@@ -178,6 +178,14 @@ func (osv *openSearchValidator) ValidateUpdate(ctx context.Context, old runtime.
 		return fmt.Errorf("cannot assert object %v to openSearch", new.GetObjectKind())
 	}
 
+	if os.Annotations[models.ResourceStateAnnotation] == models.SyncingEvent {
+		return nil
+	}
+
+	if os.Annotations[models.ExternalChangesAnnotation] == models.True {
+		return nil
+	}
+
 	if os.Status.ID == "" {
 		return osv.ValidateCreate(ctx, os)
 	}
@@ -185,19 +193,6 @@ func (osv *openSearchValidator) ValidateUpdate(ctx context.Context, old runtime.
 	opensearchlog.Info("validate update", "name", os.Name)
 
 	oldCluster := old.(*OpenSearch)
-
-	if os.Annotations[models.ResourceStateAnnotation] == models.CreatingEvent {
-		return nil
-	}
-
-	// skip validation when we receive cluster specification update from the Instaclustr Console.
-	if os.Status.ID == "" {
-		return osv.ValidateCreate(ctx, os)
-	}
-
-	if os.Annotations[models.ExternalChangesAnnotation] == models.True {
-		return nil
-	}
 
 	if oldCluster.Spec.BundledUseOnly && !oldCluster.Spec.IsEqual(os.Spec) {
 		return models.ErrBundledUseOnlyResourceUpdateIsNotSupported

--- a/apis/clusters/v1beta1/redis_webhook.go
+++ b/apis/clusters/v1beta1/redis_webhook.go
@@ -161,9 +161,7 @@ func (rv *redisValidator) ValidateUpdate(ctx context.Context, old runtime.Object
 		return fmt.Errorf("cannot assert object %v to redis", new.GetObjectKind())
 	}
 
-	redislog.Info("validate update", "name", r.Name)
-
-	if r.Annotations[models.ResourceStateAnnotation] == models.CreatingEvent {
+	if r.Annotations[models.ResourceStateAnnotation] == models.SyncingEvent {
 		return nil
 	}
 
@@ -172,13 +170,15 @@ func (rv *redisValidator) ValidateUpdate(ctx context.Context, old runtime.Object
 		return nil
 	}
 
+	if r.Status.ID == "" {
+		return rv.ValidateCreate(ctx, r)
+	}
+
+	redislog.Info("validate update", "name", r.Name)
+
 	oldRedis, ok := old.(*Redis)
 	if !ok {
 		return models.ErrTypeAssertion
-	}
-
-	if r.Status.ID == "" {
-		return rv.ValidateCreate(ctx, r)
 	}
 
 	if oldRedis.Spec.RestoreFrom != nil {

--- a/apis/clusters/v1beta1/validation.go
+++ b/apis/clusters/v1beta1/validation.go
@@ -228,7 +228,7 @@ func validateIngestNodes(new, old []*OpenSearchIngestNodes) error {
 		return models.ErrImmutableIngestNodes
 	}
 
-	if *old[0] != *new[0] {
+	if len(old) > 0 && *old[0] != *new[0] {
 		return models.ErrImmutableIngestNodes
 	}
 
@@ -240,7 +240,7 @@ func validateClusterManagedNodes(new, old []*ClusterManagerNodes) error {
 		return models.ErrImmutableClusterManagedNodes
 	}
 
-	if *old[0] != *new[0] {
+	if len(old) > 0 && *old[0] != *new[0] {
 		return models.ErrImmutableClusterManagedNodes
 	}
 

--- a/controllers/clusters/cassandra_controller.go
+++ b/controllers/clusters/cassandra_controller.go
@@ -227,6 +227,7 @@ func (r *CassandraReconciler) createCluster(ctx context.Context, c *v1beta1.Cass
 	}
 
 	c.Spec.FromInstAPI(instModel)
+	c.Annotations[models.ResourceStateAnnotation] = models.SyncingEvent
 	err = r.Update(ctx, c)
 	if err != nil {
 		return fmt.Errorf("failed to update cassandra spec, err: %w", err)
@@ -1054,7 +1055,7 @@ func (r *CassandraReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 				newObj := event.ObjectNew.(*v1beta1.Cassandra)
 
-				if newObj.Status.ID == "" && newObj.Annotations[models.ResourceStateAnnotation] == models.CreatingEvent {
+				if newObj.Status.ID == "" && newObj.Annotations[models.ResourceStateAnnotation] == models.SyncingEvent {
 					return false
 				}
 

--- a/controllers/clusters/kafka_controller.go
+++ b/controllers/clusters/kafka_controller.go
@@ -129,6 +129,7 @@ func (r *KafkaReconciler) createCluster(ctx context.Context, k *v1beta1.Kafka, l
 	)
 
 	k.Spec.FromInstAPI(&instaModel)
+	k.Annotations[models.ResourceStateAnnotation] = models.SyncingEvent
 	err = r.Update(ctx, k)
 	if err != nil {
 		return fmt.Errorf("failed to update kafka spec, err: %w", err)
@@ -692,8 +693,8 @@ func (r *KafkaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 				newObj := event.ObjectNew.(*v1beta1.Kafka)
 
-				if newObj.Status.ID == "" && newObj.Annotations[models.ResourceStateAnnotation] == models.CreatingEvent {
-					return true
+				if newObj.Status.ID == "" && newObj.Annotations[models.ResourceStateAnnotation] == models.SyncingEvent {
+					return false
 				}
 
 				if newObj.Status.ID == "" {

--- a/controllers/clusters/opensearch_controller.go
+++ b/controllers/clusters/opensearch_controller.go
@@ -195,6 +195,7 @@ func (r *OpenSearchReconciler) createCluster(ctx context.Context, o *v1beta1.Ope
 	}
 
 	o.Spec.FromInstAPI(instaModel)
+	o.Annotations[models.ResourceStateAnnotation] = models.SyncingEvent
 	err = r.Update(ctx, o)
 	if err != nil {
 		return fmt.Errorf("failed to update cluster spec, err: %w", err)
@@ -932,7 +933,7 @@ func (r *OpenSearchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 				newObj := event.ObjectNew.(*v1beta1.OpenSearch)
 
-				if newObj.Status.ID == "" && newObj.Annotations[models.ResourceStateAnnotation] == models.CreatingEvent {
+				if newObj.Status.ID == "" && newObj.Annotations[models.ResourceStateAnnotation] == models.SyncingEvent {
 					return false
 				}
 

--- a/controllers/clusters/redis_controller.go
+++ b/controllers/clusters/redis_controller.go
@@ -194,6 +194,7 @@ func (r *RedisReconciler) createCluster(ctx context.Context, redis *v1beta1.Redi
 	}
 
 	redis.Spec.FromInstAPI(instaModel)
+	redis.Annotations[models.ResourceStateAnnotation] = models.SyncingEvent
 	err = r.Update(ctx, redis)
 	if err != nil {
 		return fmt.Errorf("failed to update redis spec, err: %w", err)
@@ -961,7 +962,7 @@ func (r *RedisReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 				newObj := event.ObjectNew.(*v1beta1.Redis)
 
-				if newObj.Status.ID == "" && newObj.Annotations[models.ResourceStateAnnotation] == models.CreatingEvent {
+				if newObj.Status.ID == "" && newObj.Annotations[models.ResourceStateAnnotation] == models.SyncingEvent {
 					return false
 				}
 

--- a/pkg/models/operator.go
+++ b/pkg/models/operator.go
@@ -124,6 +124,7 @@ const (
 	GenericEvent         = "generic"
 	SecretEvent          = "secret"
 	ClusterDeletingEvent = "cluster deleting"
+	SyncingEvent         = "syncing"
 )
 
 const (


### PR DESCRIPTION
The PR changes a logic of understanding if the cluster is finishing its creation. The previous implementation uses for this the `Creating` event to skip the validation of the resource spec update to finish cluster creation. We decided to change this event to `Syncing`.
Also it provides some minor fixes for resource validation